### PR TITLE
[Feat] #33 로그인 상태유지, 신규유저 로그인시 닉네임 입력받기

### DIFF
--- a/lib/config/di/locator.dart
+++ b/lib/config/di/locator.dart
@@ -39,5 +39,5 @@ void initLocator() {
   // di.registerFactory(() => HomeBloc(di<KakaoSearchRepository>()));
   di.registerFactory(() => HomeBloc(di<GooglePlaceRepository>()));
   di.registerFactory(() => SearchBloc(di<SearchBakeryUseCase>()));
-  di.registerLazySingleton(() => LoginBloc(di<FirestoreRepository>()));
+  di.registerFactory(() => LoginBloc(di<FirestoreRepository>()));
 }

--- a/lib/config/routing/router.dart
+++ b/lib/config/routing/router.dart
@@ -3,6 +3,7 @@ import 'package:bread_place/domain/entities/bakery.dart';
 import 'package:bread_place/ui/bakery_detail/bloc/bakery_detail_bloc.dart';
 import 'package:bread_place/ui/bakery_detail/view/bakery_detail_screen.dart';
 import 'package:bread_place/ui/like/view/like_screen_main.dart';
+import 'package:bread_place/ui/login/view/edit_nickname_screen.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:bread_place/config/di/locator.dart';
 import 'package:bread_place/ui/common_widgets/main_scaffold.dart';
@@ -110,6 +111,12 @@ GoRouter router = GoRouter(
           child: const BakeryDetailScreen(),
         );
       },
+    ),
+    GoRoute(
+        path: Routes.editNickName,
+        builder: (context, state) {
+          return EditNicknameScreen();
+        }
     ),
   ],
   refreshListenable: StreamToListenable([_loginBloc.stream]),

--- a/lib/config/routing/routes.dart
+++ b/lib/config/routing/routes.dart
@@ -6,4 +6,5 @@ abstract final class Routes {
   static const mypage = '/mypage';
   static const bakeryDetail = '/bakeryDetail';
   static const like = '/like';
+  static const editNickName = '/editNickName';
 }

--- a/lib/data/repositories/firestore_repository_impl.dart
+++ b/lib/data/repositories/firestore_repository_impl.dart
@@ -10,6 +10,11 @@ class FirestoreRepositoryImpl implements FirestoreRepository {
 
   @override
   Future<bool> saveUser(UserEntity user) async {
-     return await _service.saveUser(user.toDto());
+     return await _service.saveUserId(user.toDto());
+  }
+
+  @override
+  Future<bool> isExistingUser(String uid) async {
+      return await _service.isExistingUser(uid);
   }
 }

--- a/lib/data/services/firebase/firestore_service.dart
+++ b/lib/data/services/firebase/firestore_service.dart
@@ -7,7 +7,7 @@ class FirestoreService {
   FirestoreService(this._db);
 
   // 저장되지 않은 사용자라면 신규 저장
-  Future<bool> saveUser(UserDto user) async {
+  Future<bool> saveUserId(UserDto user) async {
     try {
       bool exist = await isExistingUser(user.uid);
 
@@ -40,9 +40,5 @@ class FirestoreService {
       print("파이어베이스에 등록되지 않은 uid 입니다.. $e");
       return false;
     }
-  }
-
-  Future<void> fetchUserLike() async {
-
   }
 }

--- a/lib/data/services/firebase/firestore_service.dart
+++ b/lib/data/services/firebase/firestore_service.dart
@@ -6,19 +6,13 @@ class FirestoreService {
 
   FirestoreService(this._db);
 
+  // 저장되지 않은 사용자라면 신규 저장
   Future<bool> saveUser(UserDto user) async {
     try {
-      // 해당 uid 를 가진 사용자가 이미 있는지 확인
-      QuerySnapshot existingUsers = await _db
-          .collection('users')
-          .where('uid', isEqualTo: user.uid)
-          .limit(1)
-          .get();
-
-      print("💙 ${existingUsers.docs.length}");
+      bool exist = await isExistingUser(user.uid);
 
       // 이미 저장된 사용자
-      if (existingUsers.docs.isNotEmpty) {
+      if (exist) {
         return false;
       }
 
@@ -29,5 +23,26 @@ class FirestoreService {
       print("사용자 저장 중 오류: $e");
       return false;
     }
+  }
+
+  // 해당 uid 를 가진 사용자가 있는지 확인
+  Future<bool> isExistingUser(String uid) async {
+    try {
+      QuerySnapshot existingUsers =
+          await _db
+              .collection('users')
+              .where('uid', isEqualTo: uid)
+              .limit(1)
+              .get();
+
+      return existingUsers.docs.isNotEmpty ? true : false;
+    } catch (e) {
+      print("파이어베이스에 등록되지 않은 uid 입니다.. $e");
+      return false;
+    }
+  }
+
+  Future<void> fetchUserLike() async {
+
   }
 }

--- a/lib/data/services/local/user_local_storage.dart
+++ b/lib/data/services/local/user_local_storage.dart
@@ -16,6 +16,7 @@ class UserLocalStorage {
 
   static Future<void> saveUserId(String userId) async {
     await _prefs.setString(_userIdKey, userId);
+    await _prefs.reloadCache();
   }
 
   static Future<String?> getUserId() async {
@@ -24,5 +25,6 @@ class UserLocalStorage {
 
   static Future<void> removeUserId() async {
     await _prefs.remove(_userIdKey);
+    await _prefs.reloadCache();
   }
 }

--- a/lib/data/services/local/user_local_storage.dart
+++ b/lib/data/services/local/user_local_storage.dart
@@ -1,0 +1,28 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class UserLocalStorage {
+  static late final SharedPreferencesWithCache _prefs;
+
+  // Key 상수 정의
+  static const String _userIdKey = 'userId';
+
+  static Future<void> init() async {
+    _prefs = await SharedPreferencesWithCache.create(
+      cacheOptions: const SharedPreferencesWithCacheOptions(
+        allowList: <String>{_userIdKey},
+      ),
+    );
+  }
+
+  static Future<void> saveUserId(String userId) async {
+    await _prefs.setString(_userIdKey, userId);
+  }
+
+  static Future<String?> getUserId() async {
+    return _prefs.getString(_userIdKey);
+  }
+
+  static Future<void> removeUserId() async {
+    await _prefs.remove(_userIdKey);
+  }
+}

--- a/lib/domain/repositories/firestore_repository.dart
+++ b/lib/domain/repositories/firestore_repository.dart
@@ -2,4 +2,5 @@ import 'package:bread_place/domain/entities/user_entity.dart';
 
 abstract class FirestoreRepository {
   Future<bool> saveUser(UserEntity user);
+  Future<bool> isExistingUser(String uid);
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:bread_place/config/routing/router.dart';
 import 'package:bread_place/ui/login/bloc/login_bloc.dart';
 import 'package:bread_place/config/di/locator.dart';
+import 'data/services/local/user_local_storage.dart';
 import 'firebase_options.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -36,6 +37,7 @@ class MyApp extends StatelessWidget {
 Future<void> _initializeApp() async {
   WidgetsFlutterBinding.ensureInitialized();
   await _initEnvFile();
+  await UserLocalStorage.init();
   _initKakaoSdk();
   await _initFirebase();
   initLocator();

--- a/lib/ui/common_widgets/common_bakery_container.dart
+++ b/lib/ui/common_widgets/common_bakery_container.dart
@@ -88,8 +88,9 @@ Widget bakeryInfoText(Bakery bakery, LatLng? userLocation) {
           )
               : Text(
             "사용자 위치 정보가 없습니다",
+            overflow: TextOverflow.ellipsis,
             style: AppTextStyles.pretendardSemiBold.copyWith(
-              fontSize: 14,
+              fontSize: 12,
               color: AppColors.disabledGrey,
             ),
           ),

--- a/lib/ui/common_widgets/common_dialog.dart
+++ b/lib/ui/common_widgets/common_dialog.dart
@@ -1,0 +1,81 @@
+import 'package:bread_place/config/constants/app_colors.dart';
+import 'package:bread_place/config/constants/app_text_styles.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class CommonDialog extends StatefulWidget {
+  final String? title;
+  final String? content;
+
+  // 긍정 버튼 설정
+  final String? positiveButtonText;
+  final Color positiveButtonTextColor;
+  final VoidCallback onTapPositiveButton;
+
+  // 부정 버튼 설정
+  final String? negativeButtonText;
+  final Color negativeButtonTextColor;
+  final VoidCallback? onTapNegativeButton;
+
+  const CommonDialog({
+    super.key,
+    this.title,
+    this.content,
+    this.positiveButtonText,
+    this.negativeButtonText,
+    required this.onTapPositiveButton,
+    this.onTapNegativeButton,
+    this.positiveButtonTextColor = AppColors.fontMainBlack,
+    this.negativeButtonTextColor = AppColors.fontMainBlack,
+  });
+
+  @override
+  State<CommonDialog> createState() => _CommonDialogState();
+}
+
+class _CommonDialogState extends State<CommonDialog> {
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: widget.title == null ? SizedBox.shrink() : Text('${widget.title}'),
+      content:
+          widget.content == null
+              ? SizedBox.shrink()
+              : Text('${widget.content}'),
+      actions: [
+        // 부정 버튼
+        // negativeButtonText 또는 onTapNegativeButton 를 전달 받을 때만 생성
+        if (widget.negativeButtonText != null ||
+            widget.onTapNegativeButton != null)
+          TextButton(
+            onPressed: widget.onTapNegativeButton ?? () => context.pop(),
+            style: ButtonStyle(
+              overlayColor: WidgetStatePropertyAll(AppColors.primary),
+            ),
+            child: Text(
+              widget.negativeButtonText ?? '취소',
+              style: AppTextStyles.pretendardSemiBold.copyWith(
+                color: widget.negativeButtonTextColor,
+              ),
+            ),
+          ),
+        // 긍정 버튼
+        TextButton(
+          onPressed: widget.onTapPositiveButton,
+          style: ButtonStyle(
+            overlayColor: WidgetStatePropertyAll(AppColors.primary),
+          ),
+          child: Text(
+            widget.positiveButtonText ?? '확인',
+            style: AppTextStyles.pretendardSemiBold.copyWith(
+              color: widget.positiveButtonTextColor,
+            ),
+          ),
+        ),
+      ],
+      backgroundColor: AppColors.white,
+      titleTextStyle: AppTextStyles.pretendardSemiBold.copyWith(fontSize: 24),
+      contentTextStyle: AppTextStyles.pretendardRegular.copyWith(fontSize: 18),
+    );
+  }
+}

--- a/lib/ui/common_widgets/main_navigation_bar.dart
+++ b/lib/ui/common_widgets/main_navigation_bar.dart
@@ -2,11 +2,11 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 import 'package:bread_place/config/constants/app_colors.dart';
-import 'package:bread_place/config/di/locator.dart';
 import 'package:bread_place/config/routing/routes.dart';
 import 'package:bread_place/ui/common_widgets/login_required_dialog.dart';
 import 'package:bread_place/ui/login/bloc/login_bloc.dart';
 import 'package:bread_place/ui/login/bloc/login_state.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'package:go_router/go_router.dart';
 
@@ -22,13 +22,13 @@ class MainNavigationBar extends StatelessWidget {
 
   // 로그인하지 않은 사용자가 특정 화면 접근 시, 로그인 요구
   void _requireLoginIfProtectedTab(context, int index) {
-    // 로그인 상태
-    final loginState = di<LoginBloc>().state;
+    // 현재 로그인 상태
+    final loginState = BlocProvider.of<LoginBloc>(context).state;
 
     // 로그인이 필요한 화면 정의
     final protectedPaths = [
       Routes.review,
-      // Routes.like
+      Routes.like
     ];
 
     // 현재 탭이 로그인 필요한 화면인지 확인

--- a/lib/ui/home/bloc/home_bloc.dart
+++ b/lib/ui/home/bloc/home_bloc.dart
@@ -76,14 +76,14 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
     );
 
     // 사용자 위치 주변 베이커리 검색
-    final bakeryList = await _fetchNearby(
-      LatLng(currentPosition.latitude, currentPosition.longitude),
-    );
+    // final bakeryList = await _fetchNearby(
+    //   LatLng(currentPosition.latitude, currentPosition.longitude),
+    // );
 
     emit(
       (state as HomeScreenState).copyWith(
         hasLocationPermission: true,
-        bakeryList: bakeryList,
+        // bakeryList: bakeryList,
         lastSearchLocation: currentLatLng,
         userLocation: currentLatLng,
         mapCenter: currentLatLng,

--- a/lib/ui/home/view/home_screen_main.dart
+++ b/lib/ui/home/view/home_screen_main.dart
@@ -1,6 +1,8 @@
 import 'package:bread_place/config/constants/app_constants.dart';
 import 'package:bread_place/config/routing/routes.dart';
 import 'package:bread_place/ui/common_widgets/common_bakery_container.dart';
+import 'package:bread_place/ui/login/bloc/login_bloc.dart';
+import 'package:bread_place/ui/login/bloc/login_event.dart';
 import 'package:bread_place/utils/calculate_distance.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';

--- a/lib/ui/home/view/home_screen_main.dart
+++ b/lib/ui/home/view/home_screen_main.dart
@@ -38,6 +38,11 @@ class _HomeScreenMainState extends State<HomeScreenMain> {
   @override
   void initState() {
     super.initState();
+    _checkLogin();
+  }
+
+  void _checkLogin() {
+    context.read<LoginBloc>().add(CheckAuthStatus());
   }
 
   @override

--- a/lib/ui/like/widget/liked_bakery_container.dart
+++ b/lib/ui/like/widget/liked_bakery_container.dart
@@ -46,7 +46,7 @@ class LikedBakeryContainer extends StatelessWidget {
     return Flexible(
       child: Row(
         children: [
-          Expanded(child: _likeButton()),
+          Expanded(child: _heartButton()),
           Expanded(child: _notificationButton(false)),
         ],
       ),
@@ -54,7 +54,7 @@ class LikedBakeryContainer extends StatelessWidget {
   }
 
   //  좋아요 버튼
-  Widget _likeButton() {
+  Widget _heartButton() {
     return IconButton(
       onPressed: () {},
       icon: const Icon(CupertinoIcons.heart_fill, color: AppColors.icon),

--- a/lib/ui/login/bloc/login_bloc.dart
+++ b/lib/ui/login/bloc/login_bloc.dart
@@ -16,6 +16,8 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
     on<LoggedOut>(_onLoggedOut);
     on<CheckAuthStatus>(_onAuthStatusChecked);
     on<LoginWithKakaoRequested>(_loginWithKakao);
+    on<LoginCanceled>(_onCanceledLogin);
+    on<NicknameSubmitted>(_onNicknameSubmit);
   }
 
   // 로그아웃 처리
@@ -30,88 +32,123 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
   }
 
   // 로그인 상태 확인 처리
-  Future<void> _onAuthStatusChecked(CheckAuthStatus event, Emitter<LoginState> emit) async {
+  Future<void> _onAuthStatusChecked(
+    CheckAuthStatus event,
+    Emitter<LoginState> emit,
+  ) async {
     emit(AuthInProgress());
     String? id = await UserLocalStorage.getUserId();
 
     (id != null)
-    ? emit(Authenticated())
-    : emit(Unauthenticated());
+        ? emit(Authenticated(uid: '', createdAt: ''))
+        : emit(Unauthenticated());
   }
 
   /// 카카오 로그인 로직
-  Future<void> _loginWithKakao(LoginWithKakaoRequested event, Emitter<LoginState> emit) async {
+  Future<void> _loginWithKakao(
+    LoginWithKakaoRequested event,
+    Emitter<LoginState> emit,
+  ) async {
     try {
       bool isKakaoTalkAvailable = await isKakaoTalkInstalled();
 
+      // 로그인 시도
       isKakaoTalkAvailable
-          ? await _tryLoginWithKakaoTalk(emit)
-          : await _tryLoginWithKakaoAccount(emit);
-    } catch(e) {
-      print('카카오 로그인 실패 $e');
+          ? await _tryLoginWithKakaoTalk()
+          : await _tryLoginWithKakaoAccount();
+
+      // 로그인 성공 이후
+      final userInfo = await UserApi.instance.me();
+      final uid = userInfo.id.toString();
+      final createdAt = userInfo.connectedAt.toString();
+
+      // 로컬 저장
+      _saveUserIdToLocal(uid);
+
+      // 신규 유저 체크
+      final isNewUser = await _isNewUser(uid);
+      if (isNewUser) {
+        // 신규 유저 -> 닉네임 입력받는 화면으로 이동
+        emit(NicknameInputInProgress(uid: uid, createdAt: createdAt));
+      } else {
+        // 기존 유저 -> 인증 완료
+        emit(
+          Authenticated(uid: uid, createdAt: userInfo.connectedAt.toString()),
+        );
+      }
+    } on PlatformException catch (e) {
+      // 사용자가 로그인 취소한 경우
+      if (e.code == 'CANCELED') {
+        print('사용자 로그인 취소');
+      } else {
+        print('카카오 로그인 오류: $e');
+      }
+      emit(LoginFailure());
+    } catch (e) {
+      print('알 수 없는 로그인 오류: $e');
+      emit(LoginFailure());
     }
   }
 
   // 카카오톡 앱으로 로그인 시도
-  Future<void> _tryLoginWithKakaoTalk(Emitter<LoginState> emit) async {
-    try {
-      final token = await UserApi.instance.loginWithKakaoTalk();
-
-      if (token.accessToken.isNotEmpty) {
-        final userInfo = await _getUserInfoWithKakao();
-        await _saveUserToServerAndLocal(userInfo); // 저장
-
-        emit(Authenticated());
-      } else {
-        emit(Unauthenticated());
-      }
-    } catch (error) {
-      // 사용자가 로그인 화면에서 취소한 경우
-      if (error is PlatformException && error.code == 'CANCELED') {
-        emit(Unauthenticated());
-        return; // 이후 계정 로그인 시도하지 않음
-      }
-    }
+  Future<void> _tryLoginWithKakaoTalk() async {
+    await UserApi.instance.loginWithKakaoTalk();
   }
 
   // 카카오계정으로 로그인 시도
-  Future<void> _tryLoginWithKakaoAccount(Emitter<LoginState> emit) async {
-    try {
-      final token = await UserApi.instance.loginWithKakaoAccount();
-
-      if (token.accessToken.isNotEmpty) {
-        final userInfo = await _getUserInfoWithKakao();
-        await _saveUserToServerAndLocal(userInfo); // 저장
-
-        emit(Authenticated());
-      } else {
-        emit(Unauthenticated());
-      }
-
-    } catch (error) {
-      emit(Unauthenticated());
-      print('카카오계정으로 로그인 실패 $error');
-    }
+  Future<void> _tryLoginWithKakaoAccount() async {
+    await UserApi.instance.loginWithKakaoAccount();
   }
 
-  // 유저 정보 저장
-  Future<void> _saveUserToServerAndLocal(UserEntity user) async {
+  Future<bool> _isNewUser(String uid) async {
+    final isExist = await _repository.isExistingUser(uid);
+    return !isExist;
+  }
+
+  Future<void> _saveUserToServer(UserEntity user) async {
     try {
       await _repository.saveUser(user); // 파이어베이스 저장
-      await UserLocalStorage.saveUserId(user.uid); // 로컬 저장
     } catch (e) {
       print("_saveUserId 에러 $e");
     }
   }
 
-  // 카카오 토큰으로 유저 정보를 가져옴
-  Future<UserEntity> _getUserInfoWithKakao() async {
-    final userInfo = await UserApi.instance.me();
-    UserEntity user = UserEntity(
-        uid: userInfo.id.toString(),
-        nickname: generateTimestampNickname(), // 랜덤 닉네임 생성
-        createdAt: userInfo.connectedAt?.toIso8601String() ?? DateTime.now().toIso8601String()
-    );
-    return user;
+  Future<void> _saveUserIdToLocal(String uid) async {
+    await UserLocalStorage.saveUserId(uid);
+  }
+
+  // 닉네임 입력이 끝나면, 유저 정보 저장
+  Future<void> _onNicknameSubmit(NicknameSubmitted event, Emitter emit) async {
+    final nickname = event.nickname.trim();
+
+    // 나중에 입력하기 선택 시, 닉네임 랜덤 생성
+    final resolveNickname =
+        (nickname.isNotEmpty) ? nickname : generateTimestampNickname();
+
+    if (state is NicknameInputInProgress) {
+      final current = state as NicknameInputInProgress;
+
+      final UserEntity user = UserEntity(
+        uid: current.uid,
+        createdAt: current.createdAt,
+        nickname: resolveNickname,
+      );
+
+      await _saveUserToServer(user); // 서버 저장
+
+      // 상태 전환
+      emit(
+        Authenticated(
+          uid: user.uid,
+          createdAt: user.createdAt,
+          nickname: user.nickname,
+        ),
+      );
+    }
+  }
+
+  // 로그인 취소
+  void _onCanceledLogin(LoginCanceled event, Emitter emit) {
+    emit(LoginFailure());
   }
 }

--- a/lib/ui/login/bloc/login_event.dart
+++ b/lib/ui/login/bloc/login_event.dart
@@ -5,7 +5,6 @@ sealed class LoginEvent extends Equatable {
   List<Object?> get props => [];
 }
 
-class LoggedIn extends LoginEvent {}
 class LoggedOut extends LoginEvent {}
 class CheckAuthStatus extends LoginEvent {}
 class LoginWithKakaoRequested extends LoginEvent {}

--- a/lib/ui/login/bloc/login_event.dart
+++ b/lib/ui/login/bloc/login_event.dart
@@ -8,3 +8,21 @@ sealed class LoginEvent extends Equatable {
 class LoggedOut extends LoginEvent {}
 class CheckAuthStatus extends LoginEvent {}
 class LoginWithKakaoRequested extends LoginEvent {}
+
+class LoginCanceled extends LoginEvent {}
+
+// 닉네임 입력 시작
+class NicknameInputStarted extends LoginEvent {}
+
+// 닉네임 입력 취소
+class NicknameInputCanceled extends LoginEvent {}
+
+// 닉네임 입력 후 저장 요청
+class NicknameSubmitted extends LoginEvent {
+  final String nickname;
+
+  NicknameSubmitted(this.nickname);
+
+  @override
+  List<Object?> get props => [nickname];
+}

--- a/lib/ui/login/bloc/login_state.dart
+++ b/lib/ui/login/bloc/login_state.dart
@@ -1,10 +1,40 @@
-sealed class LoginState {}
+import 'package:equatable/equatable.dart';
+
+sealed class LoginState extends Equatable {
+  @override
+  List<Object?> get props =>  [];
+}
 
 // 인증 여부 확인 중
 class AuthInProgress extends LoginState {}
 
 // 로그인 성공
-class Authenticated extends LoginState {}
+class Authenticated extends LoginState {
+  final String uid;
+  final String createdAt;
+  final String? nickname; // nullable
+
+  Authenticated({
+    required this.uid,
+    required this.createdAt,
+    this.nickname,
+  });
+
+  Authenticated copyWith({
+    String? uid,
+    String? createdAt,
+    String? nickname,
+  }) {
+    return Authenticated(
+      uid: uid ?? this.uid,
+      createdAt: createdAt ?? this.createdAt,
+      nickname: nickname ?? this.nickname,
+    );
+  }
+
+  @override
+  List<Object?> get props => [uid, createdAt, nickname];
+}
 
 // 로그인되지 않은 상태
 class Unauthenticated extends LoginState {}
@@ -17,3 +47,20 @@ class LoginFailure extends LoginState {}
 
 // 로그아웃 실패
 class LogoutFailure extends LoginState {}
+
+// 닉네임 입력을 기다리는 상태
+class NicknameInputInProgress extends LoginState {
+  final String uid;
+  final String createdAt;
+
+  NicknameInputInProgress({
+    required this.uid,
+    required this.createdAt,
+  });
+
+  @override
+  List<Object?> get props => [uid, createdAt];
+}
+
+// 닉네임 저장 완료된 상태
+class NicknameSaved extends LoginState {}

--- a/lib/ui/login/view/edit_nickname_screen.dart
+++ b/lib/ui/login/view/edit_nickname_screen.dart
@@ -1,0 +1,140 @@
+import 'package:bread_place/ui/common_widgets/secondary_button.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+import 'package:bread_place/config/constants/app_colors.dart';
+import 'package:bread_place/ui/common_widgets/common_app_bar.dart';
+import 'package:bread_place/ui/common_widgets/common_dialog.dart';
+import 'package:bread_place/ui/common_widgets/primary_button.dart';
+import 'package:bread_place/ui/login/bloc/login_bloc.dart';
+import 'package:bread_place/ui/login/bloc/login_event.dart';
+import 'package:flutter/services.dart';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+
+class EditNicknameScreen extends StatefulWidget {
+  const EditNicknameScreen({super.key});
+
+  @override
+  State<EditNicknameScreen> createState() => _EditNicknameScreenState();
+}
+
+class _EditNicknameScreenState extends State<EditNicknameScreen> {
+  final TextEditingController _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _clearTextController();
+    super.dispose();
+  }
+
+  void _saveNickname() {
+    context.read<LoginBloc>().add(NicknameSubmitted(_controller.text));
+  }
+
+  void _showCancelDialogIfNeeded(BuildContext context) {
+    if (_controller.text.isNotEmpty) {
+      showDialog(context: context, builder: (_) => _buildCancelDialog(context));
+    } else {
+      context.pop(); // 입력이 없으면 그냥 뒤로 가기
+    }
+  }
+
+  void _clearTextController() {
+    _controller.clear();
+  }
+
+  Widget _buildCancelDialog(BuildContext context) {
+    return CommonDialog(
+      title: '닉네임이 저장되지 않았습니다',
+      content: '작성한 닉네임이 사라집니다. 그래도 뒤로 가시겠습니까?',
+      positiveButtonText: '나가기',
+      onTapPositiveButton: () {
+        _saveNickname();
+      },
+      negativeButtonText: '계속 작성',
+      onTapNegativeButton: () {
+        context.pop(); // 다이얼로그 닫기
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      child: SafeArea(
+        child: Scaffold(
+          backgroundColor: AppColors.background,
+          appBar: CommonAppBar(
+            // 백버튼
+            leading: InkWell(
+              child: Icon(CupertinoIcons.back, color: AppColors.icon),
+              onTap: () => _showCancelDialogIfNeeded(context),
+            ),
+            title: '닉네임 등록',
+          ),
+          body: Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Column(
+              children: [
+                // 텍스트 필드
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(20, 30, 20, 30),
+                  child: SizedBox(child: _inputTextField()),
+                ),
+
+                PrimaryButton(
+                  text: '저장',
+                  onPressed: () {
+                    _saveNickname();
+                    print("🩷 저장한 닉네임. text = ${_controller.text}");
+                  },
+                ),
+
+                SizedBox(height: 20),
+
+                SecondaryButton(
+                  text: '나중에 변경',
+                  onPressed: () {
+                    _clearTextController();
+                    _saveNickname();
+                    print("🩷 나중에변경 닉네임. text = ${_controller.text}");
+                  },
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _inputTextField() {
+    return TextField(
+      // 기본 밑줄 제거
+      style: TextStyle(decorationThickness: 0),
+      autofocus: true,
+      controller: _controller,
+      maxLength: 20,
+      inputFormatters: [
+        FilteringTextInputFormatter.allow(
+          RegExp(r'[a-zA-Z0-9ㄱ-ㅎㅏ-ㅣ가-힣]'), // 영어 대소문자, 숫자, 한글만 허용
+        ),
+      ],
+      decoration: InputDecoration(
+        helperText: '영어 대소문자, 숫자, 한글만 입력 가능\n최대 20자',
+        focusedBorder: OutlineInputBorder(
+          borderSide: BorderSide(color: AppColors.primary),
+        ),
+        suffixIcon: IconButton(
+          onPressed: () {
+            _clearTextController();
+          },
+          icon: Icon(CupertinoIcons.xmark_circle_fill),
+        ),
+        hintText: '사용하실 닉네임을 입력해주세요',
+      ),
+    );
+  }
+}

--- a/lib/ui/login/view/edit_nickname_screen.dart
+++ b/lib/ui/login/view/edit_nickname_screen.dart
@@ -88,7 +88,6 @@ class _EditNicknameScreenState extends State<EditNicknameScreen> {
                   text: '저장',
                   onPressed: () {
                     _saveNickname();
-                    print("🩷 저장한 닉네임. text = ${_controller.text}");
                   },
                 ),
 
@@ -99,7 +98,6 @@ class _EditNicknameScreenState extends State<EditNicknameScreen> {
                   onPressed: () {
                     _clearTextController();
                     _saveNickname();
-                    print("🩷 나중에변경 닉네임. text = ${_controller.text}");
                   },
                 ),
               ],

--- a/lib/ui/login/view/login_screen_main.dart
+++ b/lib/ui/login/view/login_screen_main.dart
@@ -5,6 +5,8 @@ import 'package:bread_place/ui/login/bloc/login_bloc.dart';
 import 'package:bread_place/ui/login/bloc/login_event.dart';
 import 'package:bread_place/config/constants/app_colors.dart';
 import 'package:bread_place/config/constants/app_text_styles.dart';
+import 'package:bread_place/config/routing/routes.dart';
+import 'package:bread_place/ui/login/bloc/login_state.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
@@ -19,24 +21,35 @@ class LoginScreenMain extends StatefulWidget {
 class _LoginScreenMainState extends State<LoginScreenMain> {
   @override
   Widget build(BuildContext context) {
-    return Material(
-      child: SafeArea(
-        child: Container(
-          color: AppColors.background,
-          child: SingleChildScrollView(
-            child: SizedBox(
-              height: 800,
-              child: Column(
-                children: [
-                  _cancelLoginButton(),
-                  Flexible(child: _titleImage()),
-                  Flexible(flex: 2, child: _content()),
+    return BlocListener<LoginBloc, LoginState>(
+      listener: (context, state) {
+        // 신규 유저 -> 닉네임 입력 화면으로 이동
+        if (state is NicknameInputInProgress) {
+          context.push(Routes.editNickName);
+          // 그 외 상태 -> 홈으로 보내기
+        } else {
+          context.go(Routes.home);
+        }
+      },
+      child: Material(
+        child: SafeArea(
+          child: Container(
+            color: AppColors.background,
+            child: SingleChildScrollView(
+              child: SizedBox(
+                height: 800,
+                child: Column(
+                  children: [
+                    _cancelLoginButton(),
+                    Flexible(child: _titleImage()),
+                    Flexible(flex: 2, child: _content()),
 
-                  SizedBox(height: 20),
-                  Flexible(child: _kakaoLoginButton()),
-                  _loginOptionButtonDivider(),
-                  Flexible(child: _guestModeButton()),
-                ],
+                    SizedBox(height: 20),
+                    Flexible(child: _kakaoLoginButton()),
+                    _loginOptionButtonDivider(),
+                    Flexible(child: _guestModeButton()),
+                  ],
+                ),
               ),
             ),
           ),
@@ -116,9 +129,11 @@ class _LoginScreenMainState extends State<LoginScreenMain> {
       child: Align(
         alignment: Alignment.topLeft,
         child: IconButton(
-            onPressed: () {
-              context.go('/home');
-            }, icon: Icon(CupertinoIcons.xmark)),
+          onPressed: () {
+            context.read<LoginBloc>().add(LoginCanceled());
+          },
+          icon: Icon(CupertinoIcons.xmark),
+        ),
       ),
     );
   }
@@ -183,7 +198,9 @@ class _LoginScreenMainState extends State<LoginScreenMain> {
           },
           style: ElevatedButton.styleFrom(
             backgroundColor: AppColors.primary,
-            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(6)),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(6),
+            ),
             shadowColor: AppColors.grey,
             elevation: 3,
           ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -958,7 +958,7 @@ packages:
     source: hosted
     version: "2.1.0"
   shared_preferences:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: shared_preferences
       sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,6 +62,8 @@ dependencies:
   firebase_storage: ^12.4.6
   firebase_messaging: ^15.2.6
 
+  shared_preferences: ^2.5.3 # caching
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
### Issue

- Close: #33 

---

### 🔴 Type of Work

- [x] feat: 새로운 기능 추가
- [ ] fix: 버그 수정
- [ ] refactor: 리팩토링
- [ ] style: 스타일 수정, 폴더 구조 조정
- [ ] docs: 문서 수정
- [ ] chore: 릴리즈 준비 작업

---

### 🔵 Description

> 구현하거나 변경한 내용을 작성해 주세요. 어떤 화면, 기능, 모듈에 영향이 있었는지 명시해 주세요.

- [x] 로컬 저장소에 uid 저장
- [x] 로그인 상태유지(카카오)
- [x] 닉네임 입력(=수정)화면 
- [x] 재사용 가능한 다이얼로그 생성
---

### 📋 Checklist

- [x] 빌드 에러가 없는 것을 확인했습니다.
- [x] 머지 대상 브랜치가 올바른지 확인했습니다.
- [x] 프로젝트의 코드 스타일 및 컨벤션을 따랐습니다.

---

### 📝 Notes for Reviewers

> 리뷰어가 참고하면 좋을 추가적인 맥락이나 유의사항이 있다면 작성해 주세요,

- LoginBloc 안에서 go.route 를 사용해 닉네임 변경화면으로 이동할 수 없어서 NicknameInputInProgress 으로 상태 변경 트리거 후 loginScreen 에서 화면 이동해주었습니다
- SharedPreferencesWithCache 는 접근이 빠르지만 한번 캐싱된 후 값을 변경해야할 경우 reloadCache(); 호출이 필요하다고 합니다. 안하면 이미 캐싱된 값을 계속 캐싱할 수도 있다고 하네요
- 로컬 저장소에 저장/삭제 하시려면 static 으로 선언한 UserLocalStorage class 사용하시면 됩니다

