### PR TITLE
[Feat] #38 notification 기본 기능 구현

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -29,6 +29,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
+        isCoreLibraryDesugaringEnabled = true
     }
 
     kotlinOptions {
@@ -66,4 +67,8 @@ android {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -17,7 +17,9 @@
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
-            android:windowSoftInputMode="adjustResize">
+            android:windowSoftInputMode="adjustResize"
+            android:showWhenLocked="true"
+            android:turnScreenOn="true">
             <!-- Specifies an Android theme to apply to this Activity as soon as
                  the Android process has started. This theme is visible to the user
                  while the Flutter UI initializes. After that, this theme continues
@@ -49,6 +51,24 @@
                 <data android:scheme="kakao${KAKAO_NATIVE_APP_KEY}" android:host="oauth"/>
             </intent-filter>
         </activity>
+
+        <!-- local_notification 관련 설정 -->
+        <receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationReceiver" />
+        <receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED"/>
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED"/>
+                <action android:name="android.intent.action.QUICKBOOT_POWERON" />
+                <action android:name="com.htc.intent.action.QUICKBOOT_POWERON"/>
+            </intent-filter>
+        </receiver>
+        <service
+            android:name="com.dexterous.flutterlocalnotifications.ForegroundService"
+            android:exported="false"
+            android:stopWithTask="false"
+            android:foregroundServiceType="location"/>
+
+
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <application
         android:label="bread_place"
         android:name="${applicationName}"

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1299,6 +1299,8 @@ PODS:
     - GoogleUtilities/Environment (~> 8.0)
     - GTMSessionFetcher/Core (< 5.0, >= 3.4)
   - Flutter (1.0.0)
+  - flutter_local_notifications (0.0.1):
+    - Flutter
   - geolocator_apple (1.2.0):
     - Flutter
     - FlutterMacOS
@@ -1478,6 +1480,7 @@ DEPENDENCIES:
   - firebase_messaging (from `.symlinks/plugins/firebase_messaging/ios`)
   - firebase_storage (from `.symlinks/plugins/firebase_storage/ios`)
   - Flutter (from `Flutter`)
+  - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
   - geolocator_apple (from `.symlinks/plugins/geolocator_apple/darwin`)
   - google_maps_flutter_ios (from `.symlinks/plugins/google_maps_flutter_ios/ios`)
   - google_sign_in_ios (from `.symlinks/plugins/google_sign_in_ios/darwin`)
@@ -1532,6 +1535,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/firebase_storage/ios"
   Flutter:
     :path: Flutter
+  flutter_local_notifications:
+    :path: ".symlinks/plugins/flutter_local_notifications/ios"
   geolocator_apple:
     :path: ".symlinks/plugins/geolocator_apple/darwin"
   google_maps_flutter_ios:
@@ -1571,6 +1576,7 @@ SPEC CHECKSUMS:
   FirebaseSharedSwift: bdd5c8674c4712a98e70287c936bc5cca5d640f6
   FirebaseStorage: e83d1b9c8a5318d46ccfb2955f0d98095e0bf598
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  flutter_local_notifications: a5a732f069baa862e728d839dd2ebb904737effb
   geolocator_apple: ab36aa0e8b7d7a2d7639b3b4e48308394e8cef5e
   Google-Maps-iOS-Utils: 66d6de12be1ce6d3742a54661e7a79cb317a9321
   google_maps_flutter_ios: 0291eb2aa252298a769b04d075e4a9d747ff7264

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -17,6 +17,10 @@ import GoogleMaps
         GMSServices.provideAPIKey(kakaoKey)
     }
 
+    if #available(iOS 10.0, *) {
+        UNUserNotificationCenter.current().delegate = self as? UNUserNotificationCenterDelegate
+    }
+
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }

--- a/lib/config/di/locator.dart
+++ b/lib/config/di/locator.dart
@@ -1,19 +1,25 @@
 import 'package:bread_place/data/repositories/firestore_repository_impl.dart';
 import 'package:bread_place/data/repositories/google_place_repository_impl.dart';
 import 'package:bread_place/data/repositories/kakao_search_repository_impl.dart';
+import 'package:bread_place/data/repositories/notification_repository_impl.dart';
 import 'package:bread_place/data/services/api/google/google_place_api.dart';
 import 'package:bread_place/data/services/api/google/google_place_dio_client.dart';
 import 'package:bread_place/data/services/api/kakao/kakao_dio_client.dart';
 import 'package:bread_place/data/services/api/kakao/kakao_local_api.dart';
 import 'package:bread_place/data/services/firebase/firestore_service.dart';
+import 'package:bread_place/data/services/notification/local_notification_service.dart';
 import 'package:bread_place/domain/repositories/firestore_repository.dart';
 import 'package:bread_place/domain/repositories/google_place_repository.dart';
 import 'package:bread_place/domain/repositories/kakao_search_repository.dart';
+import 'package:bread_place/domain/repositories/notification_repository.dart';
+import 'package:bread_place/domain/usecases/notification_use_case.dart';
 import 'package:bread_place/ui/home/bloc/home_bloc.dart';
 import 'package:bread_place/domain/usecases/search_bakery_use_case.dart';
+import 'package:bread_place/ui/like/bloc/like_bloc.dart';
 import 'package:bread_place/ui/login/bloc/login_bloc.dart';
 import 'package:bread_place/ui/search/bloc/search_bloc.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:get_it/get_it.dart';
 
 GetIt di = GetIt.instance;
@@ -28,12 +34,18 @@ void initLocator() {
   // Google_place
   di.registerLazySingleton<GooglePlaceDioClient>(() => GooglePlaceDioClient());
   di.registerLazySingleton<GooglePlaceApi>(() => GooglePlaceApi(di<GooglePlaceDioClient>().dio));
-  di.registerLazySingleton<GooglePlaceRepository>(() => GooglePlaceRepositoryImpl(googlePlaceApi: di<GooglePlaceApi>()));
+  di.registerLazySingleton< GooglePlaceRepository>(() => GooglePlaceRepositoryImpl(googlePlaceApi: di<GooglePlaceApi>()));
   di.registerLazySingleton<SearchBakeryUseCase>(() => SearchBakeryUseCase(repository: di<GooglePlaceRepository>()));
 
   // FireStore
   di.registerLazySingleton<FirestoreService>(() => FirestoreService(FirebaseFirestore.instance));
   di.registerLazySingleton<FirestoreRepository>(() => FirestoreRepositoryImpl(di<FirestoreService>()));
+  
+  // local_notification
+  di.registerLazySingleton<FlutterLocalNotificationsPlugin>(() => FlutterLocalNotificationsPlugin());
+  di.registerLazySingleton<LocalNotificationService>(() => LocalNotificationService(di<FlutterLocalNotificationsPlugin>()));
+  di.registerLazySingleton<NotificationRepository>(() => NotificationRepositoryImpl(di<LocalNotificationService>()));
+  di.registerLazySingleton<NotificationUseCase>(() => NotificationUseCase(di<NotificationRepository>()));
 
   /// Blocs
   // di.registerFactory(() => HomeBloc(di<KakaoSearchRepository>()));

--- a/lib/data/repositories/notification_repository_impl.dart
+++ b/lib/data/repositories/notification_repository_impl.dart
@@ -1,0 +1,24 @@
+import 'package:bread_place/data/services/notification/local_notification_service.dart';
+import 'package:bread_place/domain/entities/notification_entity.dart';
+import 'package:bread_place/domain/repositories/notification_repository.dart';
+
+class NotificationRepositoryImpl implements NotificationRepository {
+  final LocalNotificationService _service;
+
+  NotificationRepositoryImpl(this._service);
+
+
+  @override
+  Future<void> init() async {
+    _service.init();
+  }
+
+  @override
+  Future<void> showNotification(NotificationEntity entity) async {
+    await _service.showNotification(
+      title: entity.title,
+      body: entity.body,
+      payload: entity.payload,
+    );
+  }
+}

--- a/lib/data/services/firebase/fcm_notification_service.dart
+++ b/lib/data/services/firebase/fcm_notification_service.dart
@@ -1,0 +1,112 @@
+// import 'dart:convert';
+// import 'package:bread_place/config/routing/router.dart';
+// import 'package:bread_place/config/routing/routes.dart';
+// import 'package:bread_place/data/services/notification/local_notification_service.dart';
+// import 'package:bread_place/firebase_options.dart';
+// import 'package:firebase_core/firebase_core.dart';
+// import 'package:firebase_messaging/firebase_messaging.dart';
+//
+//
+// class FcmNotificationService {
+//   FirebaseMessaging messaging = FirebaseMessaging.instance;
+//
+//   // 알림 권한 요청
+//   Future<NotificationSettings> requestPermission() async {
+//     NotificationSettings settings = await messaging.requestPermission(
+//       alert: true,
+//       announcement: false,
+//       badge: true,
+//       carPlay: false,
+//       criticalAlert: false,
+//       provisional: false,
+//       sound: true,
+//     );
+//
+//     return settings;
+//   }
+//
+//   // 포그라운드 화면에서 알림을 수신하는 리스너 설정
+//   void setupForegroundMessaging() {
+//     FirebaseMessaging.onMessage.listen((RemoteMessage message) {
+//       String payloadData = jsonEncode(message.data);
+//
+//       ///
+//       if (message.notification != null) {
+//         LocalNotificationService.showNotification(
+//             title: message.notification!.title ?? 'message title',
+//             body: message.notification!.body ?? 'message body',
+//             payload: payloadData
+//         );
+//       }
+//
+//       print('Message data: ${message.data}');
+//       print('Message notification: ${message.notification?.title}');
+//       print('Message notification: ${message.notification?.body}');
+//       print('**************************************');
+//
+//       // TODO: 여기서 포그라운드 메시지 처리 로직 구현
+//       // 예를 들어, local_notification을 사용해서 알림 띄우기
+//       // 또는 SnackBar, Dialog 등으로 UI에 표시
+//
+//     });
+//   }
+//
+//   Future<void> getFcmToken() async {
+//     String? token = await FirebaseMessaging.instance.getToken();
+//     print("FCM Token: $token");
+//
+//     // 토큰 변경 리스너 (토큰이 갱신될 때마다 호출됨)
+//     FirebaseMessaging.instance.onTokenRefresh.listen((newToken) {
+//       print("FCM Token Refreshed: $newToken");
+//       // TODO: 새 토큰을 서버에 저장하는 로직 추가
+//     });
+//   }
+//
+//
+//   // 앱이 종료되었다가 알림 탭으로 실행될 때 메시지 처리
+//   Future<RemoteMessage?> getInitialMessage() async {
+//     // TODO: ... getInitialMessage 로직 ...
+//     return await messaging.getInitialMessage();
+//   }
+//
+//   // 앱이 백그라운드에서 알림 탭으로 포그라운드로 전환될 때 메시지 처리
+//   void setupMessageOpenedApp() {
+//     FirebaseMessaging.onMessageOpenedApp.listen((RemoteMessage message) {
+//       print('FCM Service // Message opened app: ${message.messageId}');
+//       // TODO: 알림 탭 시 특정 화면으로 이동하는 라우팅 로직
+//     });
+//   }
+//
+//   // 푸시 알림 메시지와 상호작용 정의
+//   Future<void> setupInteractedMessage() async {
+//     // 1. 앱이 종료된 상태에서 열릴 때 -> getInitialMessage 호출
+//     RemoteMessage? initialMessage = await FirebaseMessaging.instance.getInitialMessage();
+//     if (initialMessage != null) {
+//       _handleMessage(initialMessage);
+//     }
+//
+//     // 2. 앱이 백그라운드 상태일 때, 푸시 알림을 탭할 때
+//     FirebaseMessaging.onMessageOpenedApp.listen((_handleMessage));
+//   }
+//
+//   // FCM 에서 전송한 data 처리
+//   void _handleMessage(RemoteMessage message) {
+//     router.go(Routes.like);
+//   }
+// }
+//
+//
+// // 이 함수는 클래스 안에 넣지 않고 파일의 최상위에 정의해야 함
+// @pragma('vm:entry-point')
+// Future<void> firebaseMessagingBackgroundHandler(RemoteMessage message) async {
+//   await Firebase.initializeApp(
+//     options: DefaultFirebaseOptions.currentPlatform,
+//   );
+//
+//   print("FCM Background // Handling a background message: ${message.messageId}");
+//   print('FCM Background // Message data: ${message.data}');
+//   print('FCM Background // Message notification: ${message.notification?.title}');
+//   print('FCM Background // Message notification: ${message.notification?.body}');
+//
+//   // 여기서 필요한 백그라운드 작업을 수행합니다. (예: 로컬 DB 저장, 서버에 상태 보고 등)
+// }

--- a/lib/data/services/notification/local_notification_service.dart
+++ b/lib/data/services/notification/local_notification_service.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 
 class LocalNotificationService {

--- a/lib/data/services/notification/local_notification_service.dart
+++ b/lib/data/services/notification/local_notification_service.dart
@@ -1,0 +1,78 @@
+import 'dart:convert';
+
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+class LocalNotificationService {
+  final FlutterLocalNotificationsPlugin _plugin;
+
+  LocalNotificationService(this._plugin);
+
+  // 알림 시스템 초기화
+  Future<void> init() async {
+    // Android 플랫폼용 초기화 설정 (앱 아이콘 설정)
+    const AndroidInitializationSettings androidInitializationSettings =
+        AndroidInitializationSettings('@mipmap/ic_launcher');
+
+    // iOS 플랫폼용 초기화 설정 (권한 요청 여부 설정)
+    const DarwinInitializationSettings iosInitializationSettings =
+        DarwinInitializationSettings(
+          requestAlertPermission: true,
+          requestBadgePermission: true,
+          requestSoundPermission: true,
+        );
+
+    const InitializationSettings initializationSettings =
+        InitializationSettings(
+          android: androidInitializationSettings,
+          iOS: iosInitializationSettings,
+        );
+
+    // 초기화 수행
+    await _plugin.initialize(
+      initializationSettings,
+      onDidReceiveNotificationResponse: _onDidReceiveNotificationResponse,
+    );
+  }
+
+  // 플랫폼별 기본 알림 설정 정의
+  final NotificationDetails _defaultNotificationDetails = NotificationDetails(
+    // 안드로이드 알림 채널을 구분하고 설명하기 위한 값
+    android: AndroidNotificationDetails(
+      'channel id',
+      'channel name',
+      channelDescription: 'description',
+      importance: Importance.max,
+      priority: Priority.high,
+      showWhen: true,
+    ),
+    // 안드로이드 알림 채널을 구분하고 설명하기 위한 값
+    iOS: DarwinNotificationDetails(badgeNumber: 1),
+  );
+
+
+  /// 사용자가 알림을 클릭했을 때 실행되는 콜백 메서드 (background 또는 foreground 상태)
+  void _onDidReceiveNotificationResponse(NotificationResponse response) {
+    final payload = response.payload;
+    if (payload != null && payload.isNotEmpty) {
+      print("알림 클릭됨, 알림 데이터 = ${payload}");
+    }
+  }
+
+  /// 실제 알림을 디바이스에 표시하는 메서드
+  Future<void> showNotification({
+    required String title,
+    required String body,
+    required String payload, // 클릭 시 전달할 데이터
+  }) async {
+    /// payload 에서 필요한 데이터 추출해서 사용하거나..
+
+    // 알림 표시 실행
+    await _plugin.show(
+      0, // 전송을 취소하고 싶을 때 사용하는 알림 ID
+      title,
+      body,
+      _defaultNotificationDetails,
+      payload: payload,
+    );
+  }
+}

--- a/lib/data/services/permission/permission_service.dart
+++ b/lib/data/services/permission/permission_service.dart
@@ -1,0 +1,55 @@
+import 'dart:io';
+import 'package:permission_handler/permission_handler.dart';
+
+class PermissionService {
+  Future<PermissionStatus> getNotificationPermissionStatus() async {
+    if (Platform.isAndroid || Platform.isIOS) {
+      return await Permission.notification.status;
+    }
+    return PermissionStatus.denied;
+  }
+
+  Future<PermissionStatus> requestNotificationPermission() async {
+    if (Platform.isAndroid || Platform.isIOS) {
+      return await Permission.notification.request();
+    }
+    return PermissionStatus.denied;
+  }
+
+  Future<PermissionStatus> getLocationPermissionStatus() async {
+    if (Platform.isAndroid || Platform.isIOS) {
+      return await Permission.location.status;
+    }
+    return PermissionStatus.denied;
+  }
+
+  Future<PermissionStatus> requestLocationPermission() async {
+    if (Platform.isAndroid || Platform.isIOS) {
+      return await Permission.location.request();
+    }
+    return PermissionStatus.denied;
+  }
+
+  Future<PermissionStatus> getCameraPermissionStatus() async {
+    if (Platform.isAndroid || Platform.isIOS) {
+      return await Permission.camera.status;
+    }
+    return PermissionStatus.denied;
+  }
+
+  Future<PermissionStatus> requestCameraPermission() async {
+    if (Platform.isAndroid || Platform.isIOS) {
+      return await Permission.camera.request();
+    }
+    return PermissionStatus.denied;
+  }
+
+  /// 권한 요청 및 허용 여부 확인
+  Future<bool> ensurePermissionGranted(Permission permission) async {
+    final status = await permission.status;
+    if (status.isGranted) return true;
+
+    final result = await permission.request();
+    return result.isGranted;
+  }
+}

--- a/lib/domain/entities/notification_entity.dart
+++ b/lib/domain/entities/notification_entity.dart
@@ -1,0 +1,15 @@
+import 'package:bread_place/domain/entities/bakery.dart';
+
+class NotificationEntity {
+  final String title;
+  final String body;
+  final String payload;
+  final Bakery? bakery;
+
+  NotificationEntity({
+    required this.title,
+    required this.body,
+    this.payload = '',
+    this.bakery,
+  });
+}

--- a/lib/domain/repositories/notification_repository.dart
+++ b/lib/domain/repositories/notification_repository.dart
@@ -1,0 +1,6 @@
+import 'package:bread_place/domain/entities/notification_entity.dart';
+
+abstract class NotificationRepository {
+  Future<void> init();
+  Future<void> showNotification(NotificationEntity entity);
+}

--- a/lib/domain/usecases/notification_use_case.dart
+++ b/lib/domain/usecases/notification_use_case.dart
@@ -1,0 +1,21 @@
+import 'package:bread_place/domain/entities/notification_entity.dart';
+import 'package:bread_place/domain/repositories/notification_repository.dart';
+
+class NotificationUseCase {
+  final NotificationRepository _repository;
+
+  NotificationUseCase(this._repository);
+
+  Future<void> initService() async {
+    await _repository.init();
+  }
+
+  Future<void> showNotification() async {
+    final test = NotificationEntity(
+        title: '유스케이스 테스트',
+        body: '냠냠'
+    );
+
+    await _repository.showNotification(test);
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,15 +4,21 @@ import 'package:flutter/material.dart';
 import 'package:bread_place/config/routing/router.dart';
 import 'package:bread_place/ui/login/bloc/login_bloc.dart';
 import 'package:bread_place/config/di/locator.dart';
+import 'data/services/firebase/fcm_notification_service.dart';
 import 'data/services/local/user_local_storage.dart';
-import 'firebase_options.dart';
+import 'package:bread_place/data/services/notification/local_notification_service.dart';
 
+import 'firebase_options.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
 
 
 void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  // FirebaseMessaging.onBackgroundMessage(firebaseMessagingBackgroundHandler);
+
   await _initializeApp();
 
   runApp(const MyApp());
@@ -41,6 +47,10 @@ Future<void> _initializeApp() async {
   _initKakaoSdk();
   await _initFirebase();
   initLocator();
+  _initLocalNotification();
+
+  // main 함수에서도 한번, 핸들러에서도 한번 총 두번 초기화가 일어납니다.
+  // await _initFcmNotification();
 }
 
 Future<void> _initEnvFile() async {
@@ -58,3 +68,16 @@ Future<void> _initFirebase() async {
     options: DefaultFirebaseOptions.currentPlatform,
   );
 }
+
+Future<void> _initLocalNotification() async {
+  await LocalNotificationService.init();
+}
+
+// fcm
+// Future<void> _initFcmNotification() async {
+//   final fcmService = FcmNotificationService();
+//   await fcmService.requestPermission(); // 알림 권한 요청
+//
+//   fcmService.getFcmToken();
+//   fcmService.setupForegroundMessaging();
+// }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,24 +1,19 @@
-import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 
-import 'package:bread_place/config/routing/router.dart';
-import 'package:bread_place/ui/login/bloc/login_bloc.dart';
 import 'package:bread_place/config/di/locator.dart';
-import 'data/services/firebase/fcm_notification_service.dart';
+import 'package:bread_place/config/routing/router.dart';
+import 'package:bread_place/domain/usecases/notification_use_case.dart';
+import 'package:bread_place/ui/login/bloc/login_bloc.dart';
 import 'data/services/local/user_local_storage.dart';
-import 'package:bread_place/data/services/notification/local_notification_service.dart';
 
-import 'firebase_options.dart';
+import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
-import 'package:firebase_messaging/firebase_messaging.dart';
-
+import 'firebase_options.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  // FirebaseMessaging.onBackgroundMessage(firebaseMessagingBackgroundHandler);
-
   await _initializeApp();
 
   runApp(const MyApp());
@@ -41,16 +36,12 @@ class MyApp extends StatelessWidget {
 }
 
 Future<void> _initializeApp() async {
-  WidgetsFlutterBinding.ensureInitialized();
   await _initEnvFile();
   await UserLocalStorage.init();
   _initKakaoSdk();
   await _initFirebase();
   initLocator();
   _initLocalNotification();
-
-  // main 함수에서도 한번, 핸들러에서도 한번 총 두번 초기화가 일어납니다.
-  // await _initFcmNotification();
 }
 
 Future<void> _initEnvFile() async {
@@ -58,26 +49,14 @@ Future<void> _initEnvFile() async {
 }
 
 void _initKakaoSdk() {
-  KakaoSdk.init(
-      nativeAppKey: dotenv.env['KAKAO_NATIVE_APP_KEY']
-  );
+  KakaoSdk.init(nativeAppKey: dotenv.env['KAKAO_NATIVE_APP_KEY']);
 }
 
 Future<void> _initFirebase() async {
-  await Firebase.initializeApp(
-    options: DefaultFirebaseOptions.currentPlatform,
-  );
+  await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
 }
 
 Future<void> _initLocalNotification() async {
-  await LocalNotificationService.init();
+  final instance = di<NotificationUseCase>();
+  await instance.initService();
 }
-
-// fcm
-// Future<void> _initFcmNotification() async {
-//   final fcmService = FcmNotificationService();
-//   await fcmService.requestPermission(); // 알림 권한 요청
-//
-//   fcmService.getFcmToken();
-//   fcmService.setupForegroundMessaging();
-// }

--- a/lib/ui/mypage/mypage_screen_main.dart
+++ b/lib/ui/mypage/mypage_screen_main.dart
@@ -1,5 +1,11 @@
 import 'package:flutter/material.dart';
 
+import 'package:bread_place/data/services/notification/local_notification_service.dart';
+import 'package:bread_place/ui/common_widgets/common_dialog.dart';
+
+import 'package:go_router/go_router.dart';
+import 'package:permission_handler/permission_handler.dart';
+
 class MypageScreenMain extends StatefulWidget {
   const MypageScreenMain({super.key});
 
@@ -9,7 +15,59 @@ class MypageScreenMain extends StatefulWidget {
 
 class _MypageScreenMainState extends State<MypageScreenMain> {
   @override
+  void initState() {
+    super.initState();
+
+    // 첫 프레임 렌더링 이후 권한 체크 및 다이얼로그 호출
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _checkNotificationPermission();
+    });
+  }
+
+  Future<void> _checkNotificationPermission() async {
+    final granted = await LocalNotificationService.ensurePermissionGranted();
+
+    if (!mounted) return;
+
+    if (!granted) {
+      showDialog(
+        context: context,
+        builder:
+            (_) => CommonDialog(
+              title: '알람 권한 필요',
+              content: '알림 기능을 사용하려면 권한을 허용해주세요. 휴대폰 설정 화면으로 이동하시겠습니까?',
+              onTapNegativeButton: () {
+                context.pop();
+              },
+              onTapPositiveButton: () {
+                openAppSettings();
+              },
+              positiveButtonText: '이동',
+            ),
+      );
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return Column(children: [Expanded(child: Text('MypageScreenMain'))]);
+    return Column(
+      children: [
+        TextButton(
+          onPressed: () async {
+            print('3초 뒤 알림 예정...');
+
+            // 백그라운드로 전환할 시간 확보
+            Future.delayed(const Duration(seconds: 3), () {
+              LocalNotificationService.showNotification(
+                body: '테스트 알림',
+                title: '',
+                payload: '',
+              );
+            });
+          },
+          child: const Text("3초 뒤 PUSH 알림 테스트"),
+        ),
+      ],
+    );
   }
 }

--- a/lib/ui/mypage/mypage_screen_main.dart
+++ b/lib/ui/mypage/mypage_screen_main.dart
@@ -1,11 +1,5 @@
 import 'package:flutter/material.dart';
 
-import 'package:bread_place/data/services/notification/local_notification_service.dart';
-import 'package:bread_place/ui/common_widgets/common_dialog.dart';
-
-import 'package:go_router/go_router.dart';
-import 'package:permission_handler/permission_handler.dart';
-
 class MypageScreenMain extends StatefulWidget {
   const MypageScreenMain({super.key});
 
@@ -17,56 +11,14 @@ class _MypageScreenMainState extends State<MypageScreenMain> {
   @override
   void initState() {
     super.initState();
-
-    // 첫 프레임 렌더링 이후 권한 체크 및 다이얼로그 호출
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      _checkNotificationPermission();
-    });
   }
 
-  Future<void> _checkNotificationPermission() async {
-    final granted = await LocalNotificationService.ensurePermissionGranted();
-
-    if (!mounted) return;
-
-    if (!granted) {
-      showDialog(
-        context: context,
-        builder:
-            (_) => CommonDialog(
-              title: '알람 권한 필요',
-              content: '알림 기능을 사용하려면 권한을 허용해주세요. 휴대폰 설정 화면으로 이동하시겠습니까?',
-              onTapNegativeButton: () {
-                context.pop();
-              },
-              onTapPositiveButton: () {
-                openAppSettings();
-              },
-              positiveButtonText: '이동',
-            ),
-      );
-    }
-  }
 
   @override
   Widget build(BuildContext context) {
     return Column(
       children: [
-        TextButton(
-          onPressed: () async {
-            print('3초 뒤 알림 예정...');
-
-            // 백그라운드로 전환할 시간 확보
-            Future.delayed(const Duration(seconds: 3), () {
-              LocalNotificationService.showNotification(
-                body: '테스트 알림',
-                title: '',
-                payload: '',
-              );
-            });
-          },
-          child: const Text("3초 뒤 PUSH 알림 테스트"),
-        ),
+         Text("Mypage Screen"),
       ],
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -973,6 +973,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  permission_handler:
+    dependency: "direct main"
+    description:
+      name: permission_handler
+      sha256: "2d070d8684b68efb580a5997eb62f675e8a885ef0be6e754fb9ef489c177470f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.0.0+1"
+  permission_handler_android:
+    dependency: transitive
+    description:
+      name: permission_handler_android
+      sha256: "1e3bc410ca1bf84662104b100eb126e066cb55791b7451307f9708d4007350e6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.0.1"
+  permission_handler_apple:
+    dependency: transitive
+    description:
+      name: permission_handler_apple
+      sha256: f000131e755c54cf4d84a5d8bd6e4149e262cc31c5a8b1d698de1ac85fa41023
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.4.7"
+  permission_handler_html:
+    dependency: transitive
+    description:
+      name: permission_handler_html
+      sha256: "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.3+5"
+  permission_handler_platform_interface:
+    dependency: transitive
+    description:
+      name: permission_handler_platform_interface
+      sha256: eb99b295153abce5d683cac8c02e22faab63e50679b937fa1bf67d58bb282878
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.3.0"
+  permission_handler_windows:
+    dependency: transitive
+    description:
+      name: permission_handler_windows
+      sha256: "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   petitparser:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -257,6 +257,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: "79e0c23480ff85dc68de79e2cd6334add97e48f7f4865d17686dd6ea81a47e8c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.11"
   dio:
     dependency: "direct main"
     description:
@@ -454,6 +462,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.0"
+  flutter_local_notifications:
+    dependency: "direct main"
+    description:
+      name: flutter_local_notifications
+      sha256: b94a50aabbe56ef254f95f3be75640f99120429f0a153b2dc30143cffc9bfdf3
+      url: "https://pub.dev"
+    source: hosted
+    version: "19.2.1"
+  flutter_local_notifications_linux:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_linux
+      sha256: e3c277b2daab8e36ac5a6820536668d07e83851aeeb79c446e525a70710770a5
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.0"
+  flutter_local_notifications_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_platform_interface
+      sha256: "2569b973fc9d1f63a37410a9f7c1c552081226c597190cb359ef5d5762d1631c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.0.0"
+  flutter_local_notifications_windows:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_windows
+      sha256: f8fc0652a601f83419d623c85723a3e82ad81f92b33eaa9bcc21ea1b94773e6e
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -933,6 +973,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: "07c8f0b1913bcde1ff0d26e57ace2f3012ccbf2b204e070290dad3bb22797646"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.0"
   platform:
     dependency: transitive
     description:
@@ -1234,6 +1282,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.4"
+  timezone:
+    dependency: transitive
+    description:
+      name: timezone
+      sha256: dd14a3b83cfd7cb19e7888f1cbc20f258b8d71b54c06f79ac585f14093a287d1
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.1"
   timing:
     dependency: transitive
     description:
@@ -1314,6 +1370,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      sha256: b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.5.0"
   yaml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -65,6 +65,7 @@ dependencies:
   firebase_auth: ^5.0.0
 
   shared_preferences: ^2.5.3 # caching
+  flutter_local_notifications: ^19.2.1
 
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -66,6 +66,7 @@ dependencies:
 
   shared_preferences: ^2.5.3 # caching
   flutter_local_notifications: ^19.2.1
+  permission_handler: ^12.0.0+1
 
 
 dev_dependencies:

--- a/test/login_with_kakao_test.dart
+++ b/test/login_with_kakao_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
+import 'package:mocktail/mocktail.dart';
+
+
+
+// 외부 SDK를 직접 쓰지 않고, 테스트 가능한 인터페이스(추상 클래스)로 분리함
+abstract class KakaoUserApi {
+  Future<bool> isKakaoTalkInstalled();
+  Future<OAuthToken> loginWithKakaoTalk();
+  Future<OAuthToken> loginWithKakaoAccount();
+}
+
+// 위 인터페이스를 mocktail로 모킹함. 실제 SDK 없이 테스트 가능.
+class MockKakaoUserApi extends Mock implements KakaoUserApi {}
+
+class FakeOAuthToken extends Fake implements OAuthToken {}
+
+// 테스트하려는 핵심 로직.
+// 외부 의존성(Kakao SDK)을 받지 않음.
+// KakaoUserApi 를 구현한 클래스는 모두 매개변수로 받을 수 있음.
+// = 진짜 실행되는 SDK 인지, Mock SDK 인지 상관없이 받을 수 있다는 뜻.
+Future<void> login(KakaoUserApi service) async {
+
+  /// 카카오톡 앱이 설치 되어있는 경우
+  if (await service.isKakaoTalkInstalled()) {
+    try {
+      await service.loginWithKakaoTalk();
+      print('카카오톡 앱으로 로그인 성공');
+    } catch (error) {
+      print('카카오톡 앱으로 로그인 실패: $error');
+
+      // 사용자가 로그인 취소한 경우 → 아무 것도 하지 않음
+      if (error is PlatformException && error.code == 'CANCELED') return;
+
+      // 그 외 실패 -> '카카오 계정으로 로그인' 시도
+      try {
+        await service.loginWithKakaoAccount();
+        print('카카오 계정으로 로그인 성공');
+      } catch (error) {
+        print('카카오 계정으로 로그인 실패: $error');
+      }
+    }
+  } else {
+    /// 카카오톡 앱이 설치 되어 있지 않은 경우
+    try {
+      await service.loginWithKakaoAccount();
+      print('카카오 계정으로 로그인 성공');
+    } catch (error) {
+      print('카카오 계정으로 로그인 실패: $error');
+    }
+  }
+}
+
+void main() {
+  late MockKakaoUserApi mockApi;
+
+  setUpAll(() {
+    registerFallbackValue(FakeOAuthToken());
+  });
+
+  // 각 테스트마다 mock 객체 초기화
+  setUp(() {
+    mockApi = MockKakaoUserApi();
+  });
+
+  test('카카오톡 앱이 설치되어있는 상태에서 로그인 성공', () async {
+    // 카카오톡 설치되어 있다고 가정
+    when(() => mockApi.isKakaoTalkInstalled()).thenAnswer((_) async => true);
+
+    // 로그인 성공
+    when(() => mockApi.loginWithKakaoTalk()).thenAnswer((_)  async => FakeOAuthToken());
+    
+
+  });
+}
+
+
+
+


### PR DESCRIPTION
### Issue

- Close: #38 

---

### 🔴 Type of Work

- [ ] feat: 새로운 기능 추가
- [ ] fix: 버그 수정
- [ ] refactor: 리팩토링
- [ ] style: 스타일 수정, 폴더 구조 조정
- [ ] docs: 문서 수정
- [ ] chore: 릴리즈 준비 작업

---

### 🔵 Description

> 구현하거나 변경한 내용을 작성해 주세요. 어떤 화면, 기능, 모듈에 영향이 있었는지 명시해 주세요.

- [x] local_notification 으로 백그라운드, 포그라운드 상태일 때 기기에 푸시알림 구현
- [x] permission_handler 라이브러리 추가 

---

### 📋 Checklist

- [x] 빌드 에러가 없는 것을 확인했습니다.
- [x] 머지 대상 브랜치가 올바른지 확인했습니다.
- [x] 프로젝트의 코드 스타일 및 컨벤션을 따랐습니다.

---

### 📝 Notes for Reviewers

> 리뷰어가 참고하면 좋을 추가적인 맥락이나 유의사항이 있다면 작성해 주세요,

- 서버 연결이 필요한 FCM 보단 네트워크 없이 로컬 기기에 푸시 메세지를 보내는 local_notification 이 적합하다고 생각하여 변경했습니다.
- Notification UseCase 는 DI 를 통해 전역에서 사용 가능하도록 구현 했습니다.
  - Bloc 으로 주입하면 앱이 백그라운드 상태일 때 생명주기 문제 발생
  - 어느 화면에서든 쓸 수 있도록 전역 선언
 
(+추가)
- FCM 코드는 주석처리만 해서 살려두었습니다 
