### PR TITLE
[Refactor] #51 sharedPreferences 클린아키텍처 적용

### DIFF
--- a/lib/config/di/locator.dart
+++ b/lib/config/di/locator.dart
@@ -2,16 +2,19 @@ import 'package:bread_place/data/repositories/firestore_repository_impl.dart';
 import 'package:bread_place/data/repositories/google_place_repository_impl.dart';
 import 'package:bread_place/data/repositories/kakao_search_repository_impl.dart';
 import 'package:bread_place/data/repositories/notification_repository_impl.dart';
+import 'package:bread_place/data/repositories/user_local_storage_repository_impl.dart';
 import 'package:bread_place/data/services/api/google/google_place_api.dart';
 import 'package:bread_place/data/services/api/google/google_place_dio_client.dart';
 import 'package:bread_place/data/services/api/kakao/kakao_dio_client.dart';
 import 'package:bread_place/data/services/api/kakao/kakao_local_api.dart';
 import 'package:bread_place/data/services/firebase/firestore_service.dart';
+import 'package:bread_place/data/services/local/user_local_storage.dart';
 import 'package:bread_place/data/services/notification/local_notification_service.dart';
 import 'package:bread_place/domain/repositories/firestore_repository.dart';
 import 'package:bread_place/domain/repositories/google_place_repository.dart';
 import 'package:bread_place/domain/repositories/kakao_search_repository.dart';
 import 'package:bread_place/domain/repositories/notification_repository.dart';
+import 'package:bread_place/domain/repositories/user_local_storage_repository.dart';
 import 'package:bread_place/domain/usecases/notification_use_case.dart';
 import 'package:bread_place/ui/home/bloc/home_bloc.dart';
 import 'package:bread_place/domain/usecases/search_bakery_use_case.dart';
@@ -47,9 +50,26 @@ void initLocator() {
   di.registerLazySingleton<NotificationRepository>(() => NotificationRepositoryImpl(di<LocalNotificationService>()));
   di.registerLazySingleton<NotificationUseCase>(() => NotificationUseCase(di<NotificationRepository>()));
 
+  /// shared_preferences
+  // service 등록
+  di.registerSingletonAsync<UserLocalStorageService>(() async {
+    final service = UserLocalStorageService();
+    await service.init();
+    return service;
+  });
+
+  // repository 등록
+  di.registerSingletonAsync<UserLocalStorageRepository>(() async {
+    final service = await di.getAsync<UserLocalStorageService>();
+    return UserLocalStorageRepositoryImpl(service);
+  });
+
   /// Blocs
   // di.registerFactory(() => HomeBloc(di<KakaoSearchRepository>()));
   di.registerFactory(() => HomeBloc(di<GooglePlaceRepository>()));
   di.registerFactory(() => SearchBloc(di<SearchBakeryUseCase>()));
-  di.registerFactory(() => LoginBloc(di<FirestoreRepository>()));
+  di.registerFactory(() => LoginBloc(
+    di<FirestoreRepository>(),
+    di<UserLocalStorageRepository>(),
+  ));
 }

--- a/lib/data/repositories/user_local_storage_repository_impl.dart
+++ b/lib/data/repositories/user_local_storage_repository_impl.dart
@@ -1,0 +1,22 @@
+import 'package:bread_place/data/services/local/user_local_storage.dart';
+import 'package:bread_place/domain/repositories/user_local_storage_repository.dart';
+
+class UserLocalStorageRepositoryImpl implements UserLocalStorageRepository {
+  final UserLocalStorageService _service;
+  UserLocalStorageRepositoryImpl(this._service);
+
+  @override
+  Future<String?> getUserId() {
+    return _service.getUserId();
+  }
+
+  @override
+  Future<void> removeUserId() {
+    return _service.removeUserId();
+  }
+
+  @override
+  Future<void> saveUserId(String userId) {
+    return _service.saveUserId(userId);
+  }
+}

--- a/lib/data/services/local/user_local_storage.dart
+++ b/lib/data/services/local/user_local_storage.dart
@@ -1,29 +1,30 @@
 import 'package:shared_preferences/shared_preferences.dart';
 
-class UserLocalStorage {
-  static late final SharedPreferencesWithCache _prefs;
+class UserLocalStorageService {
+  late SharedPreferencesWithCache _prefs;
+  UserLocalStorageService();
 
   // Key 상수 정의
-  static const String _userIdKey = 'userId';
+  final String _userIdKey = 'userId';
 
-  static Future<void> init() async {
+  Future<void> init() async {
     _prefs = await SharedPreferencesWithCache.create(
-      cacheOptions: const SharedPreferencesWithCacheOptions(
+      cacheOptions: SharedPreferencesWithCacheOptions(
         allowList: <String>{_userIdKey},
       ),
     );
   }
 
-  static Future<void> saveUserId(String userId) async {
+  Future<void> saveUserId(String userId) async {
     await _prefs.setString(_userIdKey, userId);
     await _prefs.reloadCache();
   }
 
-  static Future<String?> getUserId() async {
+  Future<String?> getUserId() async {
     return _prefs.getString(_userIdKey);
   }
 
-  static Future<void> removeUserId() async {
+  Future<void> removeUserId() async {
     await _prefs.remove(_userIdKey);
     await _prefs.reloadCache();
   }

--- a/lib/domain/repositories/user_local_storage_repository.dart
+++ b/lib/domain/repositories/user_local_storage_repository.dart
@@ -1,0 +1,5 @@
+abstract class UserLocalStorageRepository {
+  Future<void> saveUserId(String userId);
+  Future<String?> getUserId();
+  Future<void> removeUserId();
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -37,11 +37,15 @@ class MyApp extends StatelessWidget {
 
 Future<void> _initializeApp() async {
   await _initEnvFile();
-  await UserLocalStorage.init();
+  await _initDependencies();
   _initKakaoSdk();
   await _initFirebase();
-  initLocator();
   _initLocalNotification();
+}
+
+Future<void> _initDependencies() async {
+  initLocator();
+  await di.allReady(); // 비동기 의존성 준비 완료될 때까지 대기
 }
 
 Future<void> _initEnvFile() async {

--- a/lib/ui/login/bloc/login_bloc.dart
+++ b/lib/ui/login/bloc/login_bloc.dart
@@ -1,16 +1,16 @@
-import 'package:bread_place/data/services/local/user_local_storage.dart';
 import 'package:bread_place/domain/entities/user_entity.dart';
 import 'package:bread_place/domain/repositories/firestore_repository.dart';
 import 'package:bread_place/domain/repositories/user_local_storage_repository.dart';
+import 'package:bread_place/ui/login/bloc/login_event.dart';
+import 'package:bread_place/ui/login/bloc/login_state.dart';
 import 'package:bread_place/utils/generate_timestamp_nickname.dart';
+
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 
-import 'login_event.dart';
-import 'login_state.dart';
 
 class LoginBloc extends Bloc<LoginEvent, LoginState> {
   final FirestoreRepository _firestoreRepo;

--- a/lib/ui/login/bloc/login_bloc.dart
+++ b/lib/ui/login/bloc/login_bloc.dart
@@ -1,6 +1,7 @@
 import 'package:bread_place/data/services/local/user_local_storage.dart';
 import 'package:bread_place/domain/entities/user_entity.dart';
 import 'package:bread_place/domain/repositories/firestore_repository.dart';
+import 'package:bread_place/domain/repositories/user_local_storage_repository.dart';
 import 'package:bread_place/utils/generate_timestamp_nickname.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/services.dart';
@@ -12,9 +13,10 @@ import 'login_event.dart';
 import 'login_state.dart';
 
 class LoginBloc extends Bloc<LoginEvent, LoginState> {
-  final FirestoreRepository _repository;
+  final FirestoreRepository _firestoreRepo;
+  final UserLocalStorageRepository _userLocalStorageRepo;
 
-  LoginBloc(this._repository) : super(Unauthenticated()) {
+  LoginBloc(this._firestoreRepo, this._userLocalStorageRepo) : super(Unauthenticated()) {
     on<LoggedOut>(_onLoggedOut);
     on<CheckAuthStatus>(_onAuthStatusChecked);
     on<LoginWithKakaoRequested>(_loginWithKakao);
@@ -27,7 +29,7 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
   Future<void> _onLoggedOut(LoggedOut event, Emitter<LoginState> emit) async {
     emit(AuthInProgress());
     try {
-      await UserLocalStorage.removeUserId();
+      await _userLocalStorageRepo.removeUserId();
       emit(Unauthenticated());
     } catch (e) {
       emit(LogoutFailure());
@@ -40,7 +42,7 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
     Emitter<LoginState> emit,
   ) async {
     emit(AuthInProgress());
-    String? cachedId = await UserLocalStorage.getUserId();
+    String? cachedId = await _userLocalStorageRepo.getUserId();
 
     (cachedId != null)
         ? emit(Authenticated(uid: cachedId, createdAt: ''))
@@ -65,7 +67,7 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
       final uid = userInfo.id.toString();
 
       // 로컬 저장
-      await UserLocalStorage.saveUserId(uid);
+      await _userLocalStorageRepo.saveUserId(uid);
 
       // 데이터가 없으면 신규유저
       final userData = await _fetchUserDataByUid(uid);
@@ -117,7 +119,7 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
       if (uid == null) { return Future.error(Exception('구글 로그인 실패: UID가 null입니다.'));}
       
       // 로컬 저장
-      await UserLocalStorage.saveUserId(uid);
+      await _userLocalStorageRepo.saveUserId(uid);
 
       // 데이터가 없으면 신규유저
       final userData = await _fetchUserDataByUid(uid);
@@ -192,7 +194,7 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
 
   Future<UserEntity?> _fetchUserDataByUid(String uid) async {
     try {
-      final userData = await _repository.fetchUserDataByUid(uid);
+      final userData = await _firestoreRepo.fetchUserDataByUid(uid);
       return userData;
     } catch (e) {
       print("_fetchUserData 에러 $e");
@@ -202,7 +204,7 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
 
   Future<void> _saveUserToServer(UserEntity user) async {
     try {
-      await _repository.saveUser(user); // 파이어베이스 저장
+      await _firestoreRepo.saveUser(user); // 파이어베이스 저장
     } catch (e) {
       print("_saveUserId 에러 $e");
     }


### PR DESCRIPTION
### Issue

- Close: #51 

---

### 🔴 Type of Work

- [ ] feat: 새로운 기능 추가
- [ ] fix: 버그 수정
- [x] refactor: 리팩토링
- [ ] style: 스타일 수정, 폴더 구조 조정
- [ ] docs: 문서 수정
- [ ] chore: 릴리즈 준비 작업

---

### 🔵 Description

> 구현하거나 변경한 내용을 작성해 주세요. 어떤 화면, 기능, 모듈에 영향이 있었는지 명시해 주세요.
- [x] userLocalStorageService 에 의존성 역전 원칙을 적용하여 presentation -> domain → data 방향 유지

---

### 📋 Checklist

- [x] 빌드 에러가 없는 것을 확인했습니다.
- [x] 머지 대상 브랜치가 올바른지 확인했습니다.
- [x] 프로젝트의 코드 스타일 및 컨벤션을 따랐습니다.

---

### 📝 Notes for Reviewers

> 리뷰어가 참고하면 좋을 추가적인 맥락이나 유의사항이 있다면 작성해 주세요
- UserLocalStorageService 를 registerSingletonAsync 로 등록
- 위 Service 객체를 사용해야하는 UserLocalStorageRepository 도 registerSingletonAsync 로 등록해주어야 Service 생성 후 주입 가능

