### PR TITLE
[Fix] #64 베이커리 상세뷰 노란 밑줄 안뜨도록 수정

### DIFF
--- a/lib/ui/bakery_detail/view/bakery_detail_screen.dart
+++ b/lib/ui/bakery_detail/view/bakery_detail_screen.dart
@@ -27,52 +27,54 @@ class _BakeryDetailScreenState extends State<BakeryDetailScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      color: AppColors.background,
-      child: SafeArea(
-        child: BlocBuilder<BakeryDetailBloc, BakeryDetailState>(
-          builder: (context, state) {
-            if (state is BakeryDetailInitial) {
-              final bakery = state.bakery;
-
-              return Column(
-                children: [
-                  // 커스텀 타이틀
-                  BreadPlaceTitleView(
-                    title: bakery.displayName,
-                    trailingIcon: CupertinoIcons.heart,
-                    onTrailingTap: _onHeartButtonTapped,
-                    leadingIcon: CupertinoIcons.chevron_left,
-                    onLeadingTap: _onDismissButtonTapped,
-                  ),
-
-                  Expanded(
-                    child: SingleChildScrollView(
-                      child: Column(
-                        children: [
-                          SizedBox(height: 24),
-
-                          // 베이커리 상세 뷰
-                          _BakeryDetailContentView(bakery: bakery),
-                          SizedBox(height: 24),
-
-                          // 리뷰 리스트 뷰
-                          _ReviewListView(
-                              bakery: bakery,
-                              onTrailingTap: _onAddReviewButtonTapped
-                          ),
-                        ],
+    return Scaffold(
+      body: Container(
+        color: AppColors.background,
+        child: SafeArea(
+          child: BlocBuilder<BakeryDetailBloc, BakeryDetailState>(
+            builder: (context, state) {
+              if (state is BakeryDetailInitial) {
+                final bakery = state.bakery;
+      
+                return Column(
+                  children: [
+                    // 커스텀 타이틀
+                    BreadPlaceTitleView(
+                      title: bakery.displayName,
+                      trailingIcon: CupertinoIcons.heart,
+                      onTrailingTap: _onHeartButtonTapped,
+                      leadingIcon: CupertinoIcons.chevron_left,
+                      onLeadingTap: _onDismissButtonTapped,
+                    ),
+      
+                    Expanded(
+                      child: SingleChildScrollView(
+                        child: Column(
+                          children: [
+                            SizedBox(height: 24),
+      
+                            // 베이커리 상세 뷰
+                            _BakeryDetailContentView(bakery: bakery),
+                            SizedBox(height: 24),
+      
+                            // 리뷰 리스트 뷰
+                            _ReviewListView(
+                                bakery: bakery,
+                                onTrailingTap: _onAddReviewButtonTapped
+                            ),
+                          ],
+                        ),
                       ),
                     ),
-                  ),
-
-                  SizedBox(height: 28),
-                ],
-              );
-            }
-
-            return const Center(child: CircularProgressIndicator());
-          },
+      
+                    SizedBox(height: 28),
+                  ],
+                );
+              }
+      
+              return const Center(child: CircularProgressIndicator());
+            },
+          ),
         ),
       ),
     );


### PR DESCRIPTION
### Issue

- Close: #64 

---

### 🔴 Type of Work

- [ ] feat: 새로운 기능 추가
- [x] fix: 버그 수정
- [ ] refactor: 리팩토링
- [ ] style: 스타일 수정, 폴더 구조 조정
- [ ] docs: 문서 수정
- [ ] chore: 릴리즈 준비 작업

---

### 🔵 Description

> 구현하거나 변경한 내용을 작성해 주세요. 어떤 화면, 기능, 모듈에 영향이 있었는지 명시해 주세요.

- [x] 베이커리 상세뷰에 노란 밑줄이 뜨지 않도록 뷰를 Scaffold로 감쌌습니다.

---

### 📋 Checklist

- [x] 빌드 에러가 없는 것을 확인했습니다.
- [x] 머지 대상 브랜치가 올바른지 확인했습니다.
- [x] 프로젝트의 코드 스타일 및 컨벤션을 따랐습니다.

---

### 📝 Notes for Reviewers

> 리뷰어가 참고하면 좋을 추가적인 맥락이나 유의사항이 있다면 작성해 주세요,

- 

