### PR TITLE
[Feat] #87 버튼 클릭 시 Geofence 등록/해제

### DIFF
--- a/android/app/src/main/kotlin/com/example/bread_place/geofence/GeofenceBroadcastReceiver.kt
+++ b/android/app/src/main/kotlin/com/example/bread_place/geofence/GeofenceBroadcastReceiver.kt
@@ -60,7 +60,11 @@ class GeofenceBroadcastReceiver : BroadcastReceiver() {
                 val geofences = geofencingEvent.triggeringGeofences ?: return
                 for (geofence in geofences) {
                     val id = geofence.requestId
-                    MainActivity.onEnterGeofencing?.success(id) // 플러터로 전송
+                    val event = mapOf(
+                        "event" to "onEnterGeofence",
+                        "regionId" to id
+                    )
+                    MainActivity.onEnterGeofencing?.success(event) // 플러터로 전송
                     Log.d(TAG, "Geofence 진입 $id")
                 }
             }

--- a/lib/config/di/locator.dart
+++ b/lib/config/di/locator.dart
@@ -84,7 +84,7 @@ void initLocator() {
   di.registerFactory(() => HomeBloc(di<GooglePlaceRepository>()));
   di.registerFactory(() => SearchBloc(di<SearchBakeryUseCase>()));
   di.registerFactory(() => LoginBloc(di<FirestoreRepository>(), di<UserLocalStorageRepository>(),));
-  di.registerFactory(() => LikeBloc(di<LikedBakeryUseCase>()));
+  di.registerFactory(() => LikeBloc(di<LikedBakeryUseCase>(), di<GeofencingUseCase>()));
 
 
   /// UseCase

--- a/lib/config/di/locator.dart
+++ b/lib/config/di/locator.dart
@@ -131,6 +131,7 @@ void initLocator() {
     final usecase = GeofencingUseCase(
         userLocalStorageRepository: userLocalStorageRepository,
         geofencingRepository: geofencingRepository,
+        notificationRepository: di<NotificationRepository>()
     );
 
     usecase.init();

--- a/lib/data/dto/mapper/liked_bakery_mapper.dart
+++ b/lib/data/dto/mapper/liked_bakery_mapper.dart
@@ -7,7 +7,7 @@ import 'package:bread_place/domain/entities/liked_bakery_entity.dart';
 extension LikedBakeryDtoMapper on LikedBakeryDto {
   LikedBakeryEntity toEntity({Bakery? bakery}) {
     return LikedBakeryEntity(
-      isNotify: isNotify,
+      isNotificationAllowed: isNotificationAllowed,
       updatedAt: updatedAt,
       bakery: Bakery(
           id: bakeryId,
@@ -38,7 +38,7 @@ extension LikedBakeryEntityMapper on LikedBakeryEntity {
       locationLat: bakery?.location.latitude.toString() ?? '',
       locationLong: bakery?.location.longitude.toString() ?? '',
       bakeryId: bakery?.id ?? '',
-      isNotify: isNotify,
+      isNotificationAllowed: isNotificationAllowed,
       updatedAt: updatedAt,
       displayName: bakery?.displayName ?? '',
     );

--- a/lib/data/dto/response/firebase/liked_bakery_dto.dart
+++ b/lib/data/dto/response/firebase/liked_bakery_dto.dart
@@ -5,7 +5,7 @@ part 'liked_bakery_dto.g.dart';
 @JsonSerializable()
 class LikedBakeryDto {
   final String bakeryId;
-  final bool isNotify;
+  final bool isNotificationAllowed;
   final String updatedAt;
   final String displayName;
   final String? address;
@@ -14,7 +14,7 @@ class LikedBakeryDto {
 
   LikedBakeryDto({
     required this.bakeryId,
-    required this.isNotify,
+    required this.isNotificationAllowed,
     required this.updatedAt,
     required this.displayName,
     required this.address,

--- a/lib/data/dto/response/firebase/liked_bakery_dto.g.dart
+++ b/lib/data/dto/response/firebase/liked_bakery_dto.g.dart
@@ -9,7 +9,7 @@ part of 'liked_bakery_dto.dart';
 LikedBakeryDto _$LikedBakeryDtoFromJson(Map<String, dynamic> json) =>
     LikedBakeryDto(
       bakeryId: json['bakeryId'] as String,
-      isNotify: json['isNotify'] as bool,
+      isNotificationAllowed: json['isNotificationAllowed'] as bool,
       updatedAt: json['updatedAt'] as String,
       displayName: json['displayName'] as String,
       address: json['address'] as String?,
@@ -20,7 +20,7 @@ LikedBakeryDto _$LikedBakeryDtoFromJson(Map<String, dynamic> json) =>
 Map<String, dynamic> _$LikedBakeryDtoToJson(LikedBakeryDto instance) =>
     <String, dynamic>{
       'bakeryId': instance.bakeryId,
-      'isNotify': instance.isNotify,
+      'isNotificationAllowed': instance.isNotificationAllowed,
       'updatedAt': instance.updatedAt,
       'displayName': instance.displayName,
       'address': instance.address,

--- a/lib/data/repositories/firestore_repository_impl.dart
+++ b/lib/data/repositories/firestore_repository_impl.dart
@@ -70,9 +70,9 @@ class FirestoreRepositoryImpl implements FirestoreRepository {
   }
 
   @override
-  Future<void> addLiked(String userId, LikedBakeryEntity bakery, bool isNotify) async {
+  Future<void> addLiked(String userId, LikedBakeryEntity bakery, bool isNotificationAllowed) async {
     final dto = bakery.toDto();
-    await _service.addLikedBakery(userId, dto, isNotify);
+    await _service.addLikedBakery(userId, dto, isNotificationAllowed);
   }
 
   @override
@@ -105,7 +105,7 @@ class FirestoreRepositoryImpl implements FirestoreRepository {
   }
 
   @override
-  Future<bool> toggleBakeryNotification(String userId, String bakeryId, bool isNotifying) {
-    return _service.toggleBakeryNotification(userId, bakeryId, isNotifying);
+  Future<bool> toggleBakeryNotification(String userId, String bakeryId, bool isNotificationAllowed) {
+    return _service.toggleBakeryNotification(userId, bakeryId, isNotificationAllowed);
   }
 }

--- a/lib/data/services/firebase/firestore_service.dart
+++ b/lib/data/services/firebase/firestore_service.dart
@@ -181,7 +181,7 @@ class FirestoreService {
   }
 
   Future<void> addLikedBakery(String userId, LikedBakeryDto dto,
-      bool isNotify) async {
+      bool isNotificationAllowed) async {
     await _db.collection('users').doc(userId)
         .collection('liked_bakeries').doc(dto.bakeryId)
         .set(dto.toJson());
@@ -190,17 +190,17 @@ class FirestoreService {
   Future<bool> toggleBakeryNotification(
     String userId,
     String bakeryId,
-    bool currentNotifying,
+    bool isNotificationAllowed,
   ) async {
     final DocumentReference bakeryDoc = _db
         .collection('users')
         .doc(userId)
         .collection('liked_bakeries')
         .doc(bakeryId);
-    final bool newNotifyingState = !currentNotifying;
+    final bool newState = !isNotificationAllowed;
 
     try {
-      await bakeryDoc.update({'isNotify': newNotifyingState});
+      await bakeryDoc.update({'isNotificationAllowed': newState});
       return true;
     } catch (e) {
       print("toggleBakeryNotification error : $e");

--- a/lib/data/services/firebase/firestore_service.dart
+++ b/lib/data/services/firebase/firestore_service.dart
@@ -197,10 +197,9 @@ class FirestoreService {
         .doc(userId)
         .collection('liked_bakeries')
         .doc(bakeryId);
-    final bool newState = !isNotificationAllowed;
 
     try {
-      await bakeryDoc.update({'isNotificationAllowed': newState});
+      await bakeryDoc.update({'isNotificationAllowed': isNotificationAllowed});
       return true;
     } catch (e) {
       print("toggleBakeryNotification error : $e");

--- a/lib/data/services/geofencing/geofencing_service.dart
+++ b/lib/data/services/geofencing/geofencing_service.dart
@@ -38,10 +38,11 @@ class GeofencingService {
     geofencingEventChannel
       .receiveBroadcastStream()
       .listen((dynamic event){
-        if(event is Map && event['event'] == AppConstants.onEnterGeofenceEventName){
+        if(event is Map){
+          final eventType = event['event'] as String?;
           final regionId = event['regionId'] as String?;
 
-          if(regionId != null) {
+          if(eventType == 'onEnterGeofence' && regionId != null) {
             _geofencingEnteredController.add(regionId);
           }
         }

--- a/lib/domain/entities/liked_bakery_entity.dart
+++ b/lib/domain/entities/liked_bakery_entity.dart
@@ -2,16 +2,16 @@ import 'package:bread_place/domain/entities/bakery.dart';
 import 'package:equatable/equatable.dart';
 
 class LikedBakeryEntity extends Equatable {
-  final bool isNotify;
+  final bool isNotificationAllowed;
   final String updatedAt;
   final Bakery? bakery;
 
   LikedBakeryEntity({
-    required this.isNotify,
+    required this.isNotificationAllowed,
     required this.updatedAt,
     required this.bakery,
   });
 
   @override
-  List<Object?> get props => [isNotify, updatedAt, bakery?.id];
+  List<Object?> get props => [isNotificationAllowed, updatedAt, bakery?.id];
 }

--- a/lib/domain/repositories/firestore_repository.dart
+++ b/lib/domain/repositories/firestore_repository.dart
@@ -21,8 +21,8 @@ abstract class FirestoreRepository {
     required Bakery bakery,
     FirebasePaginationCursor? cursor
   });
-  Future<void> addLiked(String userId, LikedBakeryEntity bakery, bool isNotify);
+  Future<void> addLiked(String userId, LikedBakeryEntity bakery, bool isNotificationAllowed);
   Future<void> removeLiked(String userId, String bakeryId);
   Future<List<LikedBakeryEntity>> fetchLikedBakeries(String userId);
-  Future<bool> toggleBakeryNotification(String userId, String bakeryId, bool isNotifying);
+  Future<bool> toggleBakeryNotification(String userId, String bakeryId, bool isNotificationAllowed);
 }

--- a/lib/domain/usecases/geofencing_use_case.dart
+++ b/lib/domain/usecases/geofencing_use_case.dart
@@ -23,7 +23,7 @@ class GeofencingUseCase {
     }
 
     await _userLocalStorageRepository.saveGeofencingLocations(locations);
-    final savedLocations = await _userLocalStorageRepository.getGeofencingLocations();
+    final savedLocations = await _getLocalSavedLocations();
     await _geofencingRepository.setGeofencingLocations(savedLocations);
   }
 
@@ -47,5 +47,23 @@ class GeofencingUseCase {
     _geofencingRepository.onGeofencingEntered.listen((geofenceId) {
       print('🛰️ Geofencing entered: $geofenceId');
     });
+  }
+
+  Future<List<String>> _getLocalSavedLocations() async {
+    return await _userLocalStorageRepository.getGeofencingLocations();
+  }
+
+  Future<void> updateGeofenceLocation(String location) async {
+    final savedLocations = await _getLocalSavedLocations();
+    final isAlreadySaved = savedLocations.contains(location);
+    List<String> updatedLocations;
+
+    if (isAlreadySaved) {
+      updatedLocations = savedLocations.where((e) => e != location).toList();
+    } else {
+      updatedLocations = [...savedLocations, location];
+    }
+
+    await setGeofencingLocations(updatedLocations);
   }
 }

--- a/lib/domain/usecases/geofencing_use_case.dart
+++ b/lib/domain/usecases/geofencing_use_case.dart
@@ -1,16 +1,21 @@
+import 'package:bread_place/domain/entities/notification_entity.dart';
 import 'package:bread_place/domain/repositories/geofencing_repository.dart';
+import 'package:bread_place/domain/repositories/notification_repository.dart';
 import 'package:bread_place/domain/repositories/user_local_storage_repository.dart';
 
 class GeofencingUseCase {
   final UserLocalStorageRepository _userLocalStorageRepository;
   final GeofencingRepository _geofencingRepository;
+  final NotificationRepository _notificationRepository;
 
   GeofencingUseCase({
     required UserLocalStorageRepository userLocalStorageRepository,
-    required GeofencingRepository geofencingRepository
+    required GeofencingRepository geofencingRepository,
+    required NotificationRepository notificationRepository,
   })
       : _userLocalStorageRepository = userLocalStorageRepository,
-        _geofencingRepository = geofencingRepository;
+        _geofencingRepository = geofencingRepository,
+        _notificationRepository = notificationRepository;
 
   void init() {
     _listenGeofencingEntered();
@@ -43,9 +48,22 @@ class GeofencingUseCase {
     await _geofencingRepository.stopGeofencingLocations();
   }
 
-  void _listenGeofencingEntered() {
-    _geofencingRepository.onGeofencingEntered.listen((geofenceId) {
+  Future<void> _listenGeofencingEntered() async {
+    _geofencingRepository.onGeofencingEntered.listen((geofenceId) async {
       print('🛰️ Geofencing entered: $geofenceId');
+
+      int? id = int.tryParse(geofenceId);
+      if(id == null) {
+        print("geofenceId 없음, 저장되지 않은 빵집");
+        return;
+      }
+
+      final testNoti = NotificationEntity(
+          title: '가고싶던 빵집이 근처에 있어요!',
+          body: '냠냠 $geofenceId 에 진입',
+      );
+
+      _notificationRepository.showNotification(testNoti);
     });
   }
 

--- a/lib/domain/usecases/liked_bakery_use_case.dart
+++ b/lib/domain/usecases/liked_bakery_use_case.dart
@@ -22,9 +22,9 @@ class LikedBakeryUseCase {
     }
   }
 
-  Future<void> addLike(LikedBakeryEntity likedBakery, bool isNotify) async {
+  Future<void> addLike(LikedBakeryEntity likedBakery, bool isNotificationAllowed) async {
     final userId = await getUserId();
-    await _firestoreRepo.addLiked(userId, likedBakery, isNotify);
+    await _firestoreRepo.addLiked(userId, likedBakery, isNotificationAllowed);
   }
 
   Future<void> removeLike(String bakeryId) async {

--- a/lib/domain/usecases/liked_bakery_use_case.dart
+++ b/lib/domain/usecases/liked_bakery_use_case.dart
@@ -32,11 +32,18 @@ class LikedBakeryUseCase {
     await _firestoreRepo.removeLiked(userId, bakeryId);
   }
 
+
   /// 사용자가 좋아요를 누른 베이커리 목록을 조회
   Future<List<LikedBakeryEntity>> fetchLikedBakeriesWithDetails() async {
     final userId = await getUserId();
 
     final likedBakeries = await _firestoreRepo.fetchLikedBakeries(userId);
+
+    if (likedBakeries.isNotEmpty) {
+      final locations = _getAllowedBakeryLocations(likedBakeries);
+      await _userLocalStorage.saveGeofencingLocations(locations);
+    }
+
     return likedBakeries;
   }
 
@@ -45,5 +52,19 @@ class LikedBakeryUseCase {
     final userId = await getUserId();
     bool result = await _firestoreRepo.toggleBakeryNotification(userId, bakeryId, newState);
     return result;
+  }
+
+  /// 알림 허용된 베이커리들의 위치 정보를 추출하여 문자열 리스트로 변환
+  List<String> _getAllowedBakeryLocations(List<LikedBakeryEntity> likedBakeries) {
+    return likedBakeries
+        .where((liked) => liked.isNotificationAllowed == true)
+        .map((allowed) {
+      final lat = allowed.bakery?.location.latitude;
+      final lng = allowed.bakery?.location.longitude;
+
+      if (lat != null && lng != null) {
+        return "$lat, $lng";
+      } return null;
+    }).whereType<String>().toList(); // 위치 정보 null 인 베이커리는 제외하고 리턴
   }
 }

--- a/lib/domain/usecases/liked_bakery_use_case.dart
+++ b/lib/domain/usecases/liked_bakery_use_case.dart
@@ -39,4 +39,11 @@ class LikedBakeryUseCase {
     final likedBakeries = await _firestoreRepo.fetchLikedBakeries(userId);
     return likedBakeries;
   }
+
+  /// 해당 베이커리의 알림 설정 여부를 토글하여 서버에 업데이트
+  Future<bool> updateIsNotificationAllowed(String bakeryId, bool newState) async {
+    final userId = await getUserId();
+    bool result = await _firestoreRepo.toggleBakeryNotification(userId, bakeryId, newState);
+    return result;
+  }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -77,5 +77,5 @@ Future<void> _initGeofencing() async {
   final localInstance = di<UserLocalStorageUseCase>();
 
   final locations = await localInstance.getGeofencingLocations();
-  await geofenceInstance.setTestGeofencingLocations(locations);
+  await geofenceInstance.setGeofencingLocations(locations);
 }

--- a/lib/ui/bakery_detail/view/bakery_detail_screen.dart
+++ b/lib/ui/bakery_detail/view/bakery_detail_screen.dart
@@ -54,8 +54,8 @@ class _BakeryDetailScreenState extends State<BakeryDetailScreen> {
     bool notifyByDefault = false;
 
     isLiked
-        ? context.read<LikeBloc>().add(RemoveLike(bakery: bakery, isNotify: notifyByDefault))
-        : context.read<LikeBloc>().add(AddLike(bakery: bakery, isNotify: notifyByDefault));
+        ? context.read<LikeBloc>().add(RemoveLike(bakery: bakery, isNotificationAllowed: notifyByDefault))
+        : context.read<LikeBloc>().add(AddLike(bakery: bakery, isNotificationAllowed: notifyByDefault));
   }
 
   // 현재 좋아요 상태인지 체크

--- a/lib/ui/common_widgets/common_bakery_container.dart
+++ b/lib/ui/common_widgets/common_bakery_container.dart
@@ -61,7 +61,6 @@ Widget bakeryInfoText(Bakery bakery, LatLng? userLocation) {
   return Expanded(
     flex: 2,
     child: Column(
-      mainAxisSize: MainAxisSize.min,
       mainAxisAlignment: MainAxisAlignment.center,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [

--- a/lib/ui/common_widgets/common_bakery_container.dart
+++ b/lib/ui/common_widgets/common_bakery_container.dart
@@ -60,42 +60,40 @@ Widget bakeryImageContainer(String photoUri) {
 Widget bakeryInfoText(Bakery bakery, LatLng? userLocation) {
   return Expanded(
     flex: 2,
-    child: Align(
-      alignment: Alignment.center,
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            bakery.displayName,
-            style: AppTextStyles.pretendardBold.copyWith(fontSize: 18),
-            overflow: TextOverflow.ellipsis,
+    child: Column(
+      mainAxisSize: MainAxisSize.min,
+      mainAxisAlignment: MainAxisAlignment.center,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          bakery.displayName,
+          style: AppTextStyles.pretendardBold.copyWith(fontSize: 18),
+          overflow: TextOverflow.ellipsis,
+        ),
+        SizedBox(height: 4),
+        Text(
+          bakery.formattedAddress,
+          style: AppTextStyles.pretendardRegular.copyWith(fontSize: 14),
+          overflow: TextOverflow.ellipsis,
+          maxLines: 2,
+        ),
+        userLocation != null
+            ? Text(
+          "${bakery.distanceFromUser(userLocation)}KM",
+          style: AppTextStyles.pretendardBold.copyWith(
+            fontSize: 14,
+            color: AppColors.disabledGrey,
           ),
-          SizedBox(height: 4),
-          Text(
-            bakery.formattedAddress,
-            style: AppTextStyles.pretendardRegular.copyWith(fontSize: 14),
-            overflow: TextOverflow.ellipsis,
-            maxLines: 2,
+        )
+            : Text(
+          "사용자 위치 정보가 없습니다",
+          overflow: TextOverflow.ellipsis,
+          style: AppTextStyles.pretendardSemiBold.copyWith(
+            fontSize: 12,
+            color: AppColors.disabledGrey,
           ),
-          userLocation != null
-              ? Text(
-            "${bakery.distanceFromUser(userLocation)}KM",
-            style: AppTextStyles.pretendardBold.copyWith(
-              fontSize: 14,
-              color: AppColors.disabledGrey,
-            ),
-          )
-              : Text(
-            "사용자 위치 정보가 없습니다",
-            overflow: TextOverflow.ellipsis,
-            style: AppTextStyles.pretendardSemiBold.copyWith(
-              fontSize: 12,
-              color: AppColors.disabledGrey,
-            ),
-          ),
-        ],
-      ),
+        ),
+      ],
     ),
   );
 }

--- a/lib/ui/like/bloc/like_bloc.dart
+++ b/lib/ui/like/bloc/like_bloc.dart
@@ -1,4 +1,6 @@
+import 'package:bread_place/domain/entities/bakery.dart';
 import 'package:bread_place/domain/entities/liked_bakery_entity.dart';
+import 'package:bread_place/domain/usecases/geofencing_use_case.dart';
 import 'package:bread_place/domain/usecases/liked_bakery_use_case.dart';
 import 'package:bread_place/ui/like/bloc/like_event.dart';
 import 'package:bread_place/ui/like/bloc/like_state.dart';
@@ -6,11 +8,13 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 class LikeBloc extends Bloc<LikeEvent, LikeState> {
   final LikedBakeryUseCase _likedBakeryUseCase;
+  final GeofencingUseCase _geofencingUseCase;
 
-  LikeBloc(this._likedBakeryUseCase) : super(LikeState(status: LikeStatus.initial)) {
+  LikeBloc(this._likedBakeryUseCase, this._geofencingUseCase) : super(LikeState(status: LikeStatus.initial)) {
     on<FetchLikedBakeries>(_onFetchLikedBakeries);
     on<AddLike>(_onAddLike);
     on<RemoveLike>(_onRemoveLike);
+    on<ToggleNotification>(_onToggleNotification);
   }
 
   /// 좋아요 목록에 추가
@@ -52,7 +56,6 @@ class LikeBloc extends Bloc<LikeEvent, LikeState> {
     } catch(e) {
       print("onRemoveLike 삭제 중 에러 $e");
     }
-
   }
 
   /// 서버에 저장된 좋아요 목록 가져오기
@@ -63,15 +66,8 @@ class LikeBloc extends Bloc<LikeEvent, LikeState> {
       if(likedBakeries.isEmpty) {
         emit(state.copyWith(status: LikeStatus.empty, bakeries: []));
       } else {
-
-
-
-
         emit(state.copyWith(status: LikeStatus.success, bakeries: likedBakeries));
       }
-
-
-
     } catch (e) {
       emit(state.copyWith(
         status: LikeStatus.error,
@@ -80,26 +76,43 @@ class LikeBloc extends Bloc<LikeEvent, LikeState> {
     }
   }
 
-  // 해당 빵집에 대한 위치 알림 토글
-  // 서버 저장 + 지오펜스 저장 + 알림 설정
-  Future<void> _onAddNotification(ToggleNotification event, Emitter<LikeState> emit) async {
-    // [유저 아이디] + [서버에 저장된 isNotifying on/off 토글] + [지오펜스 등록] + [지오펜스 로컬 저장]을 유스케이스에서하고..
-    // await _likedBakeryUseCase.addNotification(event.bakery.id, event.isNotify);
+  /// 해당 빵집 Notification 허용 여부 토글
+  Future<void> _onToggleNotification(ToggleNotification event,
+      Emitter<LikeState> emit) async {
+    Bakery bakery = event.bakery;
+    bool currentState = event.isNotificationAllowed;
+    final newState = !currentState;
 
-    // bloc 상태 변경
-    state.bakeries;
-    state.bakeries.first.isNotificationAllowed;
-    state.bakeries.first.bakery?.id;
+    String lat = bakery.location.latitude.toString();
+    String lng = bakery.location.longitude.toString();
+    String location = "$lat, $lng";
 
+    try {
+      await _likedBakeryUseCase.updateIsNotificationAllowed(bakery.id, newState);
+      await _geofencingUseCase.updateGeofenceLocation(location);
 
-    // 알람 바뀌었다고 안내 때리기
-    // 너무 자주 바꾸지 못하게 하기
+      final updateList = _updateIsAllowed(bakery, newState);
+
+      emit(state.copyWith(
+          bakeries: updateList,
+          status: LikeStatus.success));
+    } catch (e) {
+      emit(state.copyWith(
+          status: LikeStatus.error,
+          errorMessage: '지오펜스 또는 알림 허용 실패 $e'));
+    }
   }
 
-  // 해당 빵집에 대한 위치 알림 켜기
-  Future<void> _onRemoveNotification() async {
-
+  List<LikedBakeryEntity> _updateIsAllowed(Bakery bakery, bool isAllowed) {
+    return state.bakeries.map((liked) {
+      if (liked.bakery?.id == bakery.id) {
+        return LikedBakeryEntity(
+          isNotificationAllowed: isAllowed,
+          updatedAt: liked.updatedAt,
+          bakery: liked.bakery,
+        );
+      }
+      return liked;
+    }).toList();
   }
-
-
 }

--- a/lib/ui/like/bloc/like_bloc.dart
+++ b/lib/ui/like/bloc/like_bloc.dart
@@ -17,7 +17,7 @@ class LikeBloc extends Bloc<LikeEvent, LikeState> {
   Future<void> _onAddLike(AddLike event, Emitter emit) async {
 
     final liked = LikedBakeryEntity(
-        isNotify: event.isNotify,
+        isNotificationAllowed: event.isNotificationAllowed,
         updatedAt: DateTime.now().toIso8601String(),
         bakery: event.bakery);
 
@@ -26,7 +26,7 @@ class LikeBloc extends Bloc<LikeEvent, LikeState> {
       final updatedList = List<LikedBakeryEntity>.from(state.bakeries)
         ..add(liked);
 
-      await _likedBakeryUseCase.addLike(liked, event.isNotify); // 파이어베이스에 저장
+      await _likedBakeryUseCase.addLike(liked, event.isNotificationAllowed); // 파이어베이스에 저장
 
       emit(state.copyWith(
         status: LikeStatus.success,
@@ -88,7 +88,7 @@ class LikeBloc extends Bloc<LikeEvent, LikeState> {
 
     // bloc 상태 변경
     state.bakeries;
-    state.bakeries.first.isNotify;
+    state.bakeries.first.isNotificationAllowed;
     state.bakeries.first.bakery?.id;
 
 

--- a/lib/ui/like/bloc/like_event.dart
+++ b/lib/ui/like/bloc/like_event.dart
@@ -10,35 +10,34 @@ class FetchLikedBakeries extends LikeEvent {}
 
 class AddLike extends LikeEvent {
   final Bakery bakery;
-  final bool isNotify;
+  final bool isNotificationAllowed;
 
-  AddLike({required this.isNotify, required this.bakery});
+  AddLike({required this.isNotificationAllowed, required this.bakery});
 
   @override
-  List<Object?> get props => [bakery, isNotify];
+  List<Object?> get props => [bakery, isNotificationAllowed];
 }
 
 class RemoveLike extends LikeEvent {
   final Bakery bakery;
-  final bool isNotify;
+  final bool isNotificationAllowed;
 
-  RemoveLike({required this.bakery, required this.isNotify});
+  RemoveLike({required this.bakery, required this.isNotificationAllowed});
 
   @override
-  List<Object?> get props => [bakery, isNotify];
+  List<Object?> get props => [bakery, isNotificationAllowed];
 }
 
 class ToggleNotification extends LikeEvent {
   final Bakery bakery;
-  final bool isNotify;
+  final bool isNotificationAllowed;
 
-  ToggleNotification({required this.bakery, required this.isNotify});
+  ToggleNotification({
+    required this.bakery,
+    required this.isNotificationAllowed,
+  });
 }
 
-class AddGeofence extends LikeEvent {
+class AddGeofence extends LikeEvent {}
 
-}
-
-class RemoveGeofence extends LikeEvent {
-
-}
+class RemoveGeofence extends LikeEvent {}

--- a/lib/ui/like/view/like_screen_main.dart
+++ b/lib/ui/like/view/like_screen_main.dart
@@ -173,7 +173,7 @@ class LikedListView extends StatelessWidget {
           ),
 
           Expanded(
-            child: ListView.builder(
+            child: ListView.separated(
               padding: const EdgeInsets.fromLTRB(20, 12, 20, 12),
               itemCount: likes.length,
               itemBuilder: (context, index) {
@@ -190,7 +190,7 @@ class LikedListView extends StatelessWidget {
                   onBellButtonPressed: () => onBellButtonPressed(bakery, notify),
                   isNotified: notify,
                 );
-              },
+              }, separatorBuilder: (_, _) => const SizedBox(height: 4) // 여백
             ),
           ),
         ],
@@ -224,7 +224,7 @@ class LikedBakeryContainer extends StatelessWidget {
       onTap: onTapContainer,
       child: Container(
         height: 130,
-        padding: EdgeInsets.only(right: 6),
+        padding: EdgeInsets.fromLTRB(20,0,6,0),
         decoration: BoxDecoration(
           color: AppColors.white,
           borderRadius: BorderRadius.circular(16),

--- a/lib/ui/like/view/like_screen_main.dart
+++ b/lib/ui/like/view/like_screen_main.dart
@@ -1,4 +1,3 @@
-import 'package:bread_place/config/constants/app_text_styles.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
@@ -14,12 +13,11 @@ import 'package:bread_place/ui/search/bloc/search_state.dart';
 import 'package:bread_place/config/constants/app_colors.dart';
 import 'package:bread_place/domain/entities/bakery.dart';
 import 'package:bread_place/ui/common_widgets/common_bakery_container.dart';
-import 'package:flutter/services.dart';
+import 'package:bread_place/config/constants/app_text_styles.dart';
 
 import 'package:go_router/go_router.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
-import 'package:permission_handler/permission_handler.dart';
 
 
 class LikeScreenMain extends StatefulWidget {
@@ -84,7 +82,7 @@ Widget buildRemoveDialog(BuildContext context, Bakery bakery) {
   void onHeartButtonTapped(Bakery bakery) {
     bool notifyByDefault = false;
     context.read<LikeBloc>().add(
-      RemoveLike(bakery: bakery, isNotify: notifyByDefault),
+      RemoveLike(bakery: bakery, isNotificationAllowed: notifyByDefault),
     );
   }
 
@@ -110,7 +108,7 @@ class LikedListView extends StatelessWidget {
   Widget build(BuildContext context) {
     final likes = context.select((LikeBloc bloc) => bloc.state.bakeries);
     final isNotifyCount = likes
-        .where((likedBakery) => likedBakery.isNotify)
+        .where((likedBakery) => likedBakery.isNotificationAllowed)
         .length;
 
     // 베이커리 클릭 시, 검색 트리거
@@ -180,7 +178,7 @@ class LikedListView extends StatelessWidget {
               itemBuilder: (context, index) {
                 final likedBakery = likes[index];
                 final bakery = likedBakery.bakery;
-                final notify = likedBakery.isNotify;
+                final notify = likedBakery.isNotificationAllowed;
 
                 if (bakery == null) return const SizedBox.shrink(); // null 방지
 

--- a/lib/ui/like/view/like_screen_main.dart
+++ b/lib/ui/like/view/like_screen_main.dart
@@ -68,7 +68,7 @@ Widget heartButton(VoidCallback onPressed) {
 }
 
 // 알람 설정 버튼
-Widget notificationButton(VoidCallback onPressed, bool isNotified) {
+Widget bellButton(VoidCallback onPressed, bool isNotified) {
   return IconButton(
     onPressed: onPressed,
     icon: isNotified
@@ -124,8 +124,9 @@ class LikedListView extends StatelessWidget {
       );
     }
 
-    /// 알림 버튼 클릑 시 작동
-    void onNotifyButtonTapped() async {
+    /// 알림 버튼 클릭 시 작동
+    void onBellButtonPressed(Bakery bakery, bool isNotificationAllowed) async {
+      context.read<LikeBloc>().add(ToggleNotification(bakery: bakery, isNotificationAllowed: isNotificationAllowed));
       // TODO: UseCase로 20개 제한 코드를 옮겨야 합니다.
       if (isNotifyCount > 20) {
         return;
@@ -185,8 +186,8 @@ class LikedListView extends StatelessWidget {
                 return LikedBakeryContainer(
                   bakery: bakery,
                   onTapContainer: () => onBakeryContainerTapped(bakery),
-                  onHeartPressed: () => showRemoveDialog(context, bakery),
-                  onNotificationPressed: () => onNotifyButtonTapped(),
+                  onHeartButtonPressed: () => showRemoveDialog(context, bakery),
+                  onBellButtonPressed: () => onBellButtonPressed(bakery, notify),
                   isNotified: notify,
                 );
               },
@@ -203,8 +204,8 @@ class LikedBakeryContainer extends StatelessWidget {
   final Bakery bakery;
   final LatLng? userLocation;
   final VoidCallback onTapContainer;
-  final VoidCallback onHeartPressed;
-  final VoidCallback onNotificationPressed;
+  final VoidCallback onHeartButtonPressed;
+  final VoidCallback onBellButtonPressed;
   final bool isNotified;
 
   const LikedBakeryContainer({
@@ -212,8 +213,8 @@ class LikedBakeryContainer extends StatelessWidget {
     required this.bakery,
     this.userLocation,
     required this.onTapContainer,
-    required this.onHeartPressed,
-    required this.onNotificationPressed,
+    required this.onHeartButtonPressed,
+    required this.onBellButtonPressed,
     required this.isNotified,
   });
 
@@ -234,8 +235,8 @@ class LikedBakeryContainer extends StatelessWidget {
           children: [
             // 가게 정보
             bakeryInfoText(bakery, userLocation),
-            heartButton(onHeartPressed),
-            notificationButton(onNotificationPressed, isNotified)
+            heartButton(onHeartButtonPressed),
+            bellButton(onBellButtonPressed, isNotified)
           ],
         ),
       ),


### PR DESCRIPTION
### Issue

- Close: #87 

---

### 🔴 Type of Work

- [x] feat: 새로운 기능 추가
- [ ] fix: 버그 수정
- [ ] refactor: 리팩토링
- [ ] style: 스타일 수정, 폴더 구조 조정
- [ ] docs: 문서 수정
- [ ] chore: 릴리즈 준비 작업

---

### 🔵 Description

> 구현하거나 변경한 내용을 작성해 주세요. 어떤 화면, 기능, 모듈에 영향이 있었는지 명시해 주세요.

- [x] usecase -> bloc -> UI 연결
- [x] 좋아요 탭에서 bell 버튼 클릭 시 Geofence 등록/해제
- [x] 좋아요 탭에서 bell 버튼 클릭 시 Firebase 의 isNotificationAllowed 값 업데이트
- [x] Geofence 진입 시 notification 띄우기
---

### 📋 Checklist

- [x] 빌드 에러가 없는 것을 확인했습니다.
- [x] 머지 대상 브랜치가 올바른지 확인했습니다.
- [x] 프로젝트의 코드 스타일 및 컨벤션을 따랐습니다.

---

### 📝 Notes for Reviewers

> 리뷰어가 참고하면 좋을 추가적인 맥락이나 유의사항이 있다면 작성해 주세요,

- notification 에 띄울 내용 수정 필요
- 현재 지오펜스 진입 이벤트 발생 시 로컬에 저장된 Locations 의 index 를 전달받고 있습니다 (geofenceID)
- 그러나 "LikeState -> bakeries 에 저장된 리스트"와 "로컬에 저장된 Locations" 의 index 순서가 일치한다는 보장이 없어서, 빵집 정보의 정확도가 떨어지는 문제가 있습니다.
- 따라서 로컬에 빵집 정보까지 저장하도록 수정이 필요할 것 같습니다. (좌표 값만 있음 -> bakeryID, displayName, 좌표)

![image](https://github.com/user-attachments/assets/f57301f2-a6b3-4417-87b1-1dd829bcecb1)

