### PR TITLE
[Feat] #113 좋아요 탭 진입 시 likedBakeries 불러오도록 수정

### DIFF
--- a/lib/ui/like/view/like_screen_main.dart
+++ b/lib/ui/like/view/like_screen_main.dart
@@ -28,6 +28,11 @@ class LikeScreenMain extends StatefulWidget {
 }
 
 class _LikeScreenMainState extends State<LikeScreenMain> {
+  @override
+  void initState() {
+    super.initState();
+    context.read<LikeBloc>().add(FetchLikedBakeries());
+  }
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
### Issue

- Close: #107 
- 로그인 후 좋아요 탭 재진입시 LikeBakeries 를 불러오지 않는 문제 발견
- main 에서만 `FetchLikedBakeries` 를 트리거하고 있었기 때문에 발생한 문제

---

### 🔴 Type of Work

- [x] feat: 새로운 기능 추가
- [ ] fix: 버그 수정
- [ ] refactor: 리팩토링
- [ ] style: 스타일 수정, 폴더 구조 조정
- [ ] docs: 문서 수정
- [ ] chore: 릴리즈 준비 작업

---

### 🔵 Description

> 구현하거나 변경한 내용을 작성해 주세요. 어떤 화면, 기능, 모듈에 영향이 있었는지 명시해 주세요.

- [x] 로그인 여부에 관계없이 LikeScreen 진입 시 likedBakeries 불러오도록 함

---

### 📋 Checklist

- [x] 빌드 에러가 없는 것을 확인했습니다.
- [x] 머지 대상 브랜치가 올바른지 확인했습니다.
- [x] 프로젝트의 코드 스타일 및 컨벤션을 따랐습니다.

---

### 📝 Notes for Reviewers

> 리뷰어가 참고하면 좋을 추가적인 맥락이나 유의사항이 있다면 작성해 주세요,


- 일단 initState 에서 bloc add 하는 걸로 해결은 되었는데, 추후 더 좋은 방법이 있다면 수정하겠습니다
- 그리고 현재 router 에서 redirect 설정이 되어있습니다.. (비로그인 상태로 로그인이 필요한 페이지에 접근할 때, 로그인 페이지로 redirect)
- 이렇게 redirect 가 발생하면 LikeScreen 의 인스턴스를 새로 생성하는 것을 발견했습니다.
- 비로그인 일 때와 로그인일 때의 LikeScreen 인스턴스가 다르기 때문에 각각 initState 를 실행합니다.