### PR TITLE
[Feat] #126 닉네임 변경 72시간 1회로 제한 (최초 가입 제외)

### DIFF
--- a/lib/config/di/locator.dart
+++ b/lib/config/di/locator.dart
@@ -43,6 +43,7 @@ import 'package:bread_place/ui/home/bloc/home_bloc.dart';
 import 'package:bread_place/domain/usecases/search_bakery_use_case.dart';
 import 'package:bread_place/ui/like/bloc/like_bloc.dart';
 import 'package:bread_place/ui/login/bloc/login_bloc.dart';
+import 'package:bread_place/ui/login/bloc/nickname_edit_bloc.dart';
 import 'package:bread_place/ui/search/bloc/search_bloc.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/services.dart';
@@ -127,6 +128,7 @@ void initLocator() {
     di<UserLocalStorageUseCase>(),
   ));
   di.registerFactory(() => LikeBloc(di<LikedBakeryUseCase>(), di<GeofencingUseCase>()));
+  di.registerFactory(() => NicknameEditBloc(loginUseCase: di<LoginUseCase>()));
 
 
   /// UseCase

--- a/lib/config/routing/router.dart
+++ b/lib/config/routing/router.dart
@@ -1,3 +1,5 @@
+import 'package:bread_place/domain/usecases/login_use_case.dart';
+import 'package:bread_place/ui/login/bloc/nickname_edit_bloc.dart';
 import 'package:flutter/cupertino.dart';
 
 import 'package:bread_place/config/routing/routes.dart';
@@ -106,7 +108,10 @@ GoRouter router = GoRouter(
               path: Routes.mypage,
               pageBuilder:
                   (context, state) =>
-                      const NoTransitionPage(child: MypageScreenMain()),
+                  NoTransitionPage(
+                      child: BlocProvider(
+                          create: (_) => di<NicknameEditBloc>(),
+                          child: const MypageScreenMain())),
             ),
           ],
         ),
@@ -142,7 +147,11 @@ GoRouter router = GoRouter(
     GoRoute(
         path: Routes.editNickName,
         builder: (context, state) {
-          return EditNicknameScreen();
+          return BlocProvider(
+              create: (_) => NicknameEditBloc(
+                loginUseCase: di<LoginUseCase>()
+              ),
+              child: EditNicknameScreen());
         }
     ),
     GoRoute(

--- a/lib/data/repositories/firestore_repository_impl.dart
+++ b/lib/data/repositories/firestore_repository_impl.dart
@@ -113,4 +113,9 @@ class FirestoreRepositoryImpl implements FirestoreRepository {
   Future<void> updateUserNickname(String uid, String nickname) async {
     await _service.updateUserNicknameByUid(uid: uid, nickname: nickname);
   }
+
+  @override
+  Future<void> deleteAllUserInfo(String uid) async {
+    await _service.deleteAllUserInfo(uid: uid);
+  }
 }

--- a/lib/data/repositories/firestore_repository_impl.dart
+++ b/lib/data/repositories/firestore_repository_impl.dart
@@ -110,7 +110,7 @@ class FirestoreRepositoryImpl implements FirestoreRepository {
   }
 
   @override
-  Future<void> updateUserNickname(String uid, String nickname) async {
-    await _service.updateUserNicknameByUid(uid: uid, nickname: nickname);
+  Future<void> updateUserNickname(UserEntity user) async {
+    await _service.updateUserNicknameByUid(user: user.toDto());
   }
 }

--- a/lib/data/repositories/firestore_repository_impl.dart
+++ b/lib/data/repositories/firestore_repository_impl.dart
@@ -118,4 +118,9 @@ class FirestoreRepositoryImpl implements FirestoreRepository {
   Future<void> deleteAllUserInfo(String uid) async {
     await _service.deleteAllUserInfo(uid: uid);
   }
+
+  @override
+  Future<void> deleteAllUserInfo(String uid) async {
+    await _service.deleteAllUserInfo(uid: uid);
+  }
 }

--- a/lib/data/repositories/firestore_repository_impl.dart
+++ b/lib/data/repositories/firestore_repository_impl.dart
@@ -113,4 +113,9 @@ class FirestoreRepositoryImpl implements FirestoreRepository {
   Future<void> updateUserNickname(UserEntity user) async {
     await _service.updateUserNicknameByUid(user: user.toDto());
   }
+
+  @override
+  Future<void> deleteAllUserInfo(String uid) async {
+    await _service.deleteAllUserInfo(uid: uid);
+  }
 }

--- a/lib/data/repositories/firestore_repository_impl.dart
+++ b/lib/data/repositories/firestore_repository_impl.dart
@@ -118,9 +118,4 @@ class FirestoreRepositoryImpl implements FirestoreRepository {
   Future<void> deleteAllUserInfo(String uid) async {
     await _service.deleteAllUserInfo(uid: uid);
   }
-
-  @override
-  Future<void> deleteAllUserInfo(String uid) async {
-    await _service.deleteAllUserInfo(uid: uid);
-  }
 }

--- a/lib/data/repositories/firestore_repository_impl.dart
+++ b/lib/data/repositories/firestore_repository_impl.dart
@@ -110,8 +110,8 @@ class FirestoreRepositoryImpl implements FirestoreRepository {
   }
 
   @override
-  Future<void> updateUserNickname(String uid, String nickname) async {
-    await _service.updateUserNicknameByUid(uid: uid, nickname: nickname);
+  Future<void> updateUserNickname(UserEntity user) async {
+    await _service.updateUserNicknameByUid(user: user.toDto());
   }
 
   @override

--- a/lib/data/services/firebase/firestore_service.dart
+++ b/lib/data/services/firebase/firestore_service.dart
@@ -230,4 +230,74 @@ class FirestoreService {
       'updatedAt': user.updatedAt,
     });
   }
+
+  Future<void> deleteAllUserInfo({
+    required String uid,
+  }) async {
+    final batch = _db.batch();
+
+    final reviewsReference = await _db
+        .collection('users')
+        .doc(uid)
+        .collection('reviews')
+        .get();
+
+    for (final doc in reviewsReference.docs){
+      final reviewId = doc.id;
+
+      // 1. users/{uid}/reviews/{reviewId} 삭제
+      batch.delete(doc.reference);
+
+      // 2. reviews/{reviewId} 삭제
+      final reviewReference = _db
+          .collection('reviews')
+          .doc(reviewId);
+
+      batch.delete(reviewReference);
+
+      // 3. bakery/{bakeryId}/reviews/{reviewId} 삭제
+      final reviewDoc = await reviewReference.get();
+
+      if(reviewDoc.exists){
+        final data = reviewDoc.data();
+        final bakeryId = data?['bakeryId'];
+
+        if(bakeryId != null && bakeryId is String){
+          final bakeryReviewReference = _db
+              .collection('bakery')
+              .doc(bakeryId)
+              .collection('reviews')
+              .doc(reviewId);
+
+          batch.delete(bakeryReviewReference);
+        }
+
+        // 4. 리뷰 이미지 삭제
+        final imageUrl = data?['imageUrl'];
+
+        if(imageUrl != null && imageUrl is String){
+          final imageReference = FirebaseStorage.instance.refFromURL(imageUrl);
+          await imageReference.delete();
+        }
+      }
+    }
+
+    // 5. users/{uid}/liked_bakeries 삭제
+    final likedBakeriesReference = await _db
+        .collection('users')
+        .doc(uid)
+        .collection('liked_bakeries')
+        .get();
+
+    for (final doc in likedBakeriesReference.docs) {
+      batch.delete(doc.reference);
+    }
+
+    await batch.commit();
+
+    // 6. (users/{uid}) 삭제
+    await _db.collection('users')
+        .doc(uid)
+        .delete();
+  }
 }

--- a/lib/data/services/firebase/firestore_service.dart
+++ b/lib/data/services/firebase/firestore_service.dart
@@ -221,14 +221,13 @@ class FirestoreService {
   }
 
   Future<void> updateUserNicknameByUid({
-    required String uid,
-    required String nickname,
+    required UserDto user,
   }) async {
-    final docRef = _db.collection('users').doc(uid);
+    final docRef = _db.collection('users').doc(user.uid);
 
     await docRef.update({
-      'nickname': nickname,
-      'updatedAt': DateTime.now().toIso8601String(),
+      'nickname': user.nickname,
+      'updatedAt': user.updatedAt,
     });
   }
 }

--- a/lib/data/services/firebase/firestore_service.dart
+++ b/lib/data/services/firebase/firestore_service.dart
@@ -221,14 +221,13 @@ class FirestoreService {
   }
 
   Future<void> updateUserNicknameByUid({
-    required String uid,
-    required String nickname,
+    required UserDto user,
   }) async {
-    final docRef = _db.collection('users').doc(uid);
+    final docRef = _db.collection('users').doc(user.uid);
 
     await docRef.update({
-      'nickname': nickname,
-      'updatedAt': DateTime.now().toIso8601String(),
+      'nickname': user.nickname,
+      'updatedAt': user.updatedAt,
     });
   }
 

--- a/lib/data/services/firebase/firestore_service.dart
+++ b/lib/data/services/firebase/firestore_service.dart
@@ -231,4 +231,74 @@ class FirestoreService {
       'updatedAt': DateTime.now().toIso8601String(),
     });
   }
+
+  Future<void> deleteAllUserInfo({
+    required String uid,
+  }) async {
+    final batch = _db.batch();
+
+    final reviewsReference = await _db
+        .collection('users')
+        .doc(uid)
+        .collection('reviews')
+        .get();
+
+    for (final doc in reviewsReference.docs){
+      final reviewId = doc.id;
+
+      // 1. users/{uid}/reviews/{reviewId} 삭제
+      batch.delete(doc.reference);
+
+      // 2. reviews/{reviewId} 삭제
+      final reviewReference = _db
+          .collection('reviews')
+          .doc(reviewId);
+
+      batch.delete(reviewReference);
+
+      // 3. bakery/{bakeryId}/reviews/{reviewId} 삭제
+      final reviewDoc = await reviewReference.get();
+
+      if(reviewDoc.exists){
+        final data = reviewDoc.data();
+        final bakeryId = data?['bakeryId'];
+
+        if(bakeryId != null && bakeryId is String){
+          final bakeryReviewReference = _db
+              .collection('bakery')
+              .doc(bakeryId)
+              .collection('reviews')
+              .doc(reviewId);
+
+          batch.delete(bakeryReviewReference);
+        }
+
+        // 4. 리뷰 이미지 삭제
+        final imageUrl = data?['imageUrl'];
+
+        if(imageUrl != null && imageUrl is String){
+          final imageReference = FirebaseStorage.instance.refFromURL(imageUrl);
+          await imageReference.delete();
+        }
+      }
+    }
+
+    // 5. users/{uid}/liked_bakeries 삭제
+    final likedBakeriesReference = await _db
+        .collection('users')
+        .doc(uid)
+        .collection('liked_bakeries')
+        .get();
+
+    for (final doc in likedBakeriesReference.docs) {
+      batch.delete(doc.reference);
+    }
+
+    await batch.commit();
+
+    // 6. (users/{uid}) 삭제
+    await _db.collection('users')
+        .doc(uid)
+        .delete();
+  }
 }

--- a/lib/domain/repositories/firestore_repository.dart
+++ b/lib/domain/repositories/firestore_repository.dart
@@ -25,6 +25,6 @@ abstract class FirestoreRepository {
   Future<void> removeLiked(String userId, String bakeryId);
   Future<List<LikedBakeryEntity>> fetchLikedBakeries(String userId);
   Future<bool> toggleBakeryNotification(String userId, String bakeryId, bool isNotificationAllowed);
-  Future<void> updateUserNickname(String uid, String nickname);
   Future<void> deleteAllUserInfo(String uid);
+  Future<void> updateUserNickname(UserEntity user);
 }

--- a/lib/domain/repositories/firestore_repository.dart
+++ b/lib/domain/repositories/firestore_repository.dart
@@ -25,5 +25,6 @@ abstract class FirestoreRepository {
   Future<void> removeLiked(String userId, String bakeryId);
   Future<List<LikedBakeryEntity>> fetchLikedBakeries(String userId);
   Future<bool> toggleBakeryNotification(String userId, String bakeryId, bool isNotificationAllowed);
+  Future<void> deleteAllUserInfo(String uid);
   Future<void> updateUserNickname(UserEntity user);
 }

--- a/lib/domain/repositories/firestore_repository.dart
+++ b/lib/domain/repositories/firestore_repository.dart
@@ -26,4 +26,5 @@ abstract class FirestoreRepository {
   Future<List<LikedBakeryEntity>> fetchLikedBakeries(String userId);
   Future<bool> toggleBakeryNotification(String userId, String bakeryId, bool isNotificationAllowed);
   Future<void> updateUserNickname(String uid, String nickname);
+  Future<void> deleteAllUserInfo(String uid);
 }

--- a/lib/domain/repositories/firestore_repository.dart
+++ b/lib/domain/repositories/firestore_repository.dart
@@ -25,5 +25,5 @@ abstract class FirestoreRepository {
   Future<void> removeLiked(String userId, String bakeryId);
   Future<List<LikedBakeryEntity>> fetchLikedBakeries(String userId);
   Future<bool> toggleBakeryNotification(String userId, String bakeryId, bool isNotificationAllowed);
-  Future<void> updateUserNickname(String uid, String nickname);
+  Future<void> updateUserNickname(UserEntity user);
 }

--- a/lib/domain/usecases/login_use_case.dart
+++ b/lib/domain/usecases/login_use_case.dart
@@ -78,11 +78,13 @@ class LoginUseCase {
     }
   }
 
-  Future<void> updateUserNickname(String uid, String nickname) async {
-    await _firestoreRepository.updateUserNickname(uid, nickname);
+  Future<void> updateUserNickname(UserEntity user) async {
+    await _firestoreRepository.updateUserNickname(user);
+    await _userLocalStorageRepository.saveUserNickname(user.nickname);
   }
 
   Future<void> saveNewUser(UserEntity user) async {
     await _firestoreRepository.saveUser(user);
+    await _userLocalStorageRepository.saveUserNickname(user.nickname);
   }
 }

--- a/lib/domain/usecases/login_use_case.dart
+++ b/lib/domain/usecases/login_use_case.dart
@@ -68,6 +68,23 @@ class LoginUseCase {
     _geofencingRepository.stopGeofencingLocations();
   }
 
+  Future<void> withDraw() async {
+    // 로컬에 등록된 유저 UID 가져오기
+    final uid = await _userLocalStorageRepository.getUserId();
+
+    print("uid:        $uid");
+
+    if(uid != null) {
+      // 서버의 모든 유저 데이터 삭제
+      await _firestoreRepository.deleteAllUserInfo(uid);
+
+      print("uid:        $uid");
+
+      // 로그아웃 진행(로컬 데이터 삭제)
+      await logout();
+    }
+  }
+
   Future<UserEntity?> getUserDataByUid(String uid) async {
     try {
       final userData = await _firestoreRepository.fetchUserDataByUid(uid);

--- a/lib/domain/usecases/login_use_case.dart
+++ b/lib/domain/usecases/login_use_case.dart
@@ -95,11 +95,13 @@ class LoginUseCase {
     }
   }
 
-  Future<void> updateUserNickname(String uid, String nickname) async {
-    await _firestoreRepository.updateUserNickname(uid, nickname);
+  Future<void> updateUserNickname(UserEntity user) async {
+    await _firestoreRepository.updateUserNickname(user);
+    await _userLocalStorageRepository.saveUserNickname(user.nickname);
   }
 
   Future<void> saveNewUser(UserEntity user) async {
     await _firestoreRepository.saveUser(user);
+    await _userLocalStorageRepository.saveUserNickname(user.nickname);
   }
 }

--- a/lib/ui/login/bloc/login_bloc.dart
+++ b/lib/ui/login/bloc/login_bloc.dart
@@ -26,8 +26,6 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
     on<WithDraw>(_onWithDraw);
     on<CheckAuthStatus>(_onAuthStatusChecked);
     on<LoginCanceled>(_onCanceledLogin);
-    on<NicknameSubmitted>(_onNicknameSubmit);
-    on<OpenNicknameEditScreen>(_onOpenNicknameEditScreen);
     on<LoginRequested>((event, emit) async {
       await _login(event, emit);
     });
@@ -83,11 +81,9 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
 
       // 신규 유저 -> 닉네임 입력받는 화면으로 이동
       if (userData == null) {
-        emit(NicknameEditing(
-            uid: uid,
-            createdAt: DateTime.now().toIso8601String(),
-            isNewUser: true)
-        );
+        emit(NewUserRequireNickname(
+          uid: uid
+        ));
       } else {
         // 기존 유저 -> 아이디, 닉네임 저장
         await _userLocalStorageRepo.saveUserId(userData.uid);
@@ -106,46 +102,6 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
     } on LoginFailedException {
       emit(LoginFailure());
     }
-  }
-
-  // 닉네임 입력이 끝나면, 유저 정보 저장
-  Future<void> _onNicknameSubmit(NicknameSubmitted event, Emitter emit) async {
-    try {
-      final currentState = state;
-
-      if (currentState is NicknameEditing) {
-        String uid = currentState.uid;
-        String createdAt = currentState.createdAt;
-        bool isNewUser = currentState.isNewUser;
-        String nickname = event.nickname.trim();
-
-        final UserEntity updatedNickname = UserEntity(
-            uid: uid,
-            createdAt: createdAt,
-            nickname: nickname
-        );
-
-        if(isNewUser) {
-          await _loginUseCase.saveNewUser(updatedNickname);
-        } else {
-          await _loginUseCase.updateUserNickname(uid, nickname);
-        }
-
-        emit(NicknameEdited());
-
-        await _userLocalStorageUseCase.saveUidAndNickname(uid, nickname);
-        emit(Authenticated(uid: uid, createdAt: createdAt, nickname: nickname));
-      }
-
-    } catch(e) {
-      emit(NicknameEditFailure());
-    }
-
-  }
-
-  //
-  void _onOpenNicknameEditScreen(OpenNicknameEditScreen event, Emitter emit) {
-    emit(NicknameEditing(uid: event.uid, createdAt: event.createdAt, isNewUser: false));
   }
 
   // 로그인 취소

--- a/lib/ui/login/bloc/login_bloc.dart
+++ b/lib/ui/login/bloc/login_bloc.dart
@@ -23,6 +23,7 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
       this._userLocalStorageUseCase
   ): super(Unauthenticated()) {
     on<LoggedOut>(_onLoggedOut);
+    on<WithDraw>(_onWithDraw);
     on<CheckAuthStatus>(_onAuthStatusChecked);
     on<LoginCanceled>(_onCanceledLogin);
     on<NicknameSubmitted>(_onNicknameSubmit);
@@ -37,6 +38,16 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
     emit(AuthInProgress());
     try {
       await _loginUseCase.logout();
+      emit(Unauthenticated());
+    } catch (e) {
+      emit(LogoutFailure());
+    }
+  }
+
+  Future<void> _onWithDraw(WithDraw event, Emitter<LoginState> emit) async {
+    emit(AuthInProgress());
+    try {
+      await _loginUseCase.withDraw();
       emit(Unauthenticated());
     } catch (e) {
       emit(LogoutFailure());

--- a/lib/ui/login/bloc/login_bloc.dart
+++ b/lib/ui/login/bloc/login_bloc.dart
@@ -25,8 +25,6 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
     on<LoggedOut>(_onLoggedOut);
     on<CheckAuthStatus>(_onAuthStatusChecked);
     on<LoginCanceled>(_onCanceledLogin);
-    on<NicknameSubmitted>(_onNicknameSubmit);
-    on<OpenNicknameEditScreen>(_onOpenNicknameEditScreen);
     on<LoginRequested>((event, emit) async {
       await _login(event, emit);
     });
@@ -72,11 +70,9 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
 
       // 신규 유저 -> 닉네임 입력받는 화면으로 이동
       if (userData == null) {
-        emit(NicknameEditing(
-            uid: uid,
-            createdAt: DateTime.now().toIso8601String(),
-            isNewUser: true)
-        );
+        emit(NewUserRequireNickname(
+          uid: uid
+        ));
       } else {
         // 기존 유저 -> 아이디, 닉네임 저장
         await _userLocalStorageRepo.saveUserId(userData.uid);
@@ -95,46 +91,6 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
     } on LoginFailedException {
       emit(LoginFailure());
     }
-  }
-
-  // 닉네임 입력이 끝나면, 유저 정보 저장
-  Future<void> _onNicknameSubmit(NicknameSubmitted event, Emitter emit) async {
-    try {
-      final currentState = state;
-
-      if (currentState is NicknameEditing) {
-        String uid = currentState.uid;
-        String createdAt = currentState.createdAt;
-        bool isNewUser = currentState.isNewUser;
-        String nickname = event.nickname.trim();
-
-        final UserEntity updatedNickname = UserEntity(
-            uid: uid,
-            createdAt: createdAt,
-            nickname: nickname
-        );
-
-        if(isNewUser) {
-          await _loginUseCase.saveNewUser(updatedNickname);
-        } else {
-          await _loginUseCase.updateUserNickname(uid, nickname);
-        }
-
-        emit(NicknameEdited());
-
-        await _userLocalStorageUseCase.saveUidAndNickname(uid, nickname);
-        emit(Authenticated(uid: uid, createdAt: createdAt, nickname: nickname));
-      }
-
-    } catch(e) {
-      emit(NicknameEditFailure());
-    }
-
-  }
-
-  //
-  void _onOpenNicknameEditScreen(OpenNicknameEditScreen event, Emitter emit) {
-    emit(NicknameEditing(uid: event.uid, createdAt: event.createdAt, isNewUser: false));
   }
 
   // 로그인 취소

--- a/lib/ui/login/bloc/login_bloc.dart
+++ b/lib/ui/login/bloc/login_bloc.dart
@@ -23,6 +23,7 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
       this._userLocalStorageUseCase
   ): super(Unauthenticated()) {
     on<LoggedOut>(_onLoggedOut);
+    on<WithDraw>(_onWithDraw);
     on<CheckAuthStatus>(_onAuthStatusChecked);
     on<LoginCanceled>(_onCanceledLogin);
     on<LoginRequested>((event, emit) async {
@@ -35,6 +36,16 @@ class LoginBloc extends Bloc<LoginEvent, LoginState> {
     emit(AuthInProgress());
     try {
       await _loginUseCase.logout();
+      emit(Unauthenticated());
+    } catch (e) {
+      emit(LogoutFailure());
+    }
+  }
+
+  Future<void> _onWithDraw(WithDraw event, Emitter<LoginState> emit) async {
+    emit(AuthInProgress());
+    try {
+      await _loginUseCase.withDraw();
       emit(Unauthenticated());
     } catch (e) {
       emit(LogoutFailure());

--- a/lib/ui/login/bloc/login_event.dart
+++ b/lib/ui/login/bloc/login_event.dart
@@ -20,21 +20,3 @@ class LoginRequested extends LoginEvent {
 }
 
 class LoginCanceled extends LoginEvent {}
-
-// 닉네임 입력 후 저장 요청
-class NicknameSubmitted extends LoginEvent {
-  final String nickname;
-
-  NicknameSubmitted(this.nickname);
-
-  @override
-  List<Object?> get props => [nickname];
-}
-
-class OpenNicknameEditScreen extends LoginEvent {
-  final String uid;
-  final String createdAt;
-  final String? oldNickname;
-
-  OpenNicknameEditScreen({required this.uid, required this.createdAt, this.oldNickname});
-}

--- a/lib/ui/login/bloc/login_event.dart
+++ b/lib/ui/login/bloc/login_event.dart
@@ -19,21 +19,3 @@ class LoginRequested extends LoginEvent {
 }
 
 class LoginCanceled extends LoginEvent {}
-
-// 닉네임 입력 후 저장 요청
-class NicknameSubmitted extends LoginEvent {
-  final String nickname;
-
-  NicknameSubmitted(this.nickname);
-
-  @override
-  List<Object?> get props => [nickname];
-}
-
-class OpenNicknameEditScreen extends LoginEvent {
-  final String uid;
-  final String createdAt;
-  final String? oldNickname;
-
-  OpenNicknameEditScreen({required this.uid, required this.createdAt, this.oldNickname});
-}

--- a/lib/ui/login/bloc/login_event.dart
+++ b/lib/ui/login/bloc/login_event.dart
@@ -7,6 +7,7 @@ sealed class LoginEvent extends Equatable {
 }
 
 class LoggedOut extends LoginEvent {}
+class WithDraw extends LoginEvent {}
 class CheckAuthStatus extends LoginEvent {}
 
 // 로그인 요청

--- a/lib/ui/login/bloc/login_state.dart
+++ b/lib/ui/login/bloc/login_state.dart
@@ -48,19 +48,9 @@ class LoginFailure extends LoginState {}
 // 로그아웃 실패
 class LogoutFailure extends LoginState {}
 
-// 닉네임 수정 중인 상태
-class NicknameEditing extends LoginState {
+// 신규 유저라면 닉네임 등록 화면으로 이동
+class NewUserRequireNickname extends LoginState {
   final String uid;
-  final String createdAt;
-  final String? oldNickname;
-  final bool isNewUser;
 
-  NicknameEditing({required this.uid, required this.createdAt, this.oldNickname, required this.isNewUser});
-
-  @override
-  List<Object?> get props => [uid, createdAt, oldNickname, isNewUser];
+  NewUserRequireNickname({required this.uid});
 }
-
-class NicknameEditFailure extends LoginState {}
-
-class NicknameEdited extends LoginState {}

--- a/lib/ui/login/bloc/nickname_edit_bloc.dart
+++ b/lib/ui/login/bloc/nickname_edit_bloc.dart
@@ -14,63 +14,52 @@ class NicknameEditBloc extends Bloc<NicknameEditEvent, NicknameEditState> {
     on<SubmitNickname>(_onSubmitNickname);
   }
 
-
   Future<void> _onCheckNicknameChangeAvailability(
-    CheckNicknameChangeAvailability event,
-    Emitter<NicknameEditState> emit,
-  ) async {
-
-    if(event.isNewUser) {
-      emit(
-        NicknameChangeAvailable(
-          uid: event.uid,
-          isNewUser: true,
-          createdAt: DateTime.now().toIso8601String(),
-        ),
-      );
-      return;
-    }
-
-    final fetchedUserData = await _loginUseCase.getUserDataByUid(event.uid);
-
-    if (fetchedUserData == null) {
-      emit(NicknameDataFetchFailure());
-      return;
-    }
-
-    // 신규 유저 최초 1회 등록 시
-    if (fetchedUserData.updatedAt.isEmpty) {
-      emit(
-        NicknameChangeAvailable(
-          uid: event.uid,
-          isNewUser: true,
-          createdAt: fetchedUserData.createdAt,
-        ),
-      );
-      return;
-    }
-
+      CheckNicknameChangeAvailability event,
+      Emitter<NicknameEditState> emit,
+      ) async {
     try {
-      final updatedTime = DateTime.parse(fetchedUserData.updatedAt).toLocal();
-      final now = DateTime.now();
-      final diff = now.difference(updatedTime);
-
-      // 변경 후 72 시간 지남
-      if (diff.inHours >= 72) {
-        emit(
-          NicknameChangeAvailable(
-            uid: event.uid,
-            isNewUser: false,
-            createdAt: fetchedUserData.createdAt,
-            updatedAt: fetchedUserData.updatedAt,
-          ),
-        );
-      } else {
-        // 변경 후 72 시간 안지남
-        emit(NicknameChangeUnavailable(Duration(hours: 72) - diff));
-      }
-    } catch (_) {
+      final stateResult = await _evaluateNicknameChangeStatus(event.uid);
+      emit(stateResult);
+    } catch (e) {
       emit(NicknameChangeUnavailable(Duration(hours: 72)));
+    }
+  }
+
+  Future<NicknameEditState> _evaluateNicknameChangeStatus(String uid) async {
+    final userData = await _loginUseCase.getUserDataByUid(uid);
+
+    // 신규 유저 - 아직 DB에 존재하지 않음
+    if (userData == null) {
+      return NicknameChangeAvailable(
+        uid: uid,
+        isNewUser: true,
+        createdAt: DateTime.now().toIso8601String(),
+      );
+    }
+
+    // 기존 유저 - 가입할 때 닉네임 저장 이후 updatedAt 없음 → 최초 1회는 제한없이 변경 허용
+    if (userData.updatedAt.isEmpty) {
+      return NicknameChangeAvailable(
+        uid: uid,
+        isNewUser: false,
+        createdAt: userData.createdAt,
+      );
+    }
+
+    // 기존 유저 - 72시간 제한 검사
+    final updatedTime = DateTime.parse(userData.updatedAt).toLocal();
+    final diff = DateTime.now().difference(updatedTime);
+
+    if (diff.inHours >= 72) {
+      return NicknameChangeAvailable(
+        uid: uid,
+        isNewUser: false,
+        createdAt: userData.createdAt,
+        updatedAt: userData.updatedAt,
+      );
+    } else {
+      return NicknameChangeUnavailable(Duration(hours: 72) - diff);
     }
   }
 

--- a/lib/ui/login/bloc/nickname_edit_bloc.dart
+++ b/lib/ui/login/bloc/nickname_edit_bloc.dart
@@ -1,0 +1,108 @@
+import 'package:bread_place/domain/entities/user_entity.dart';
+import 'package:bread_place/domain/usecases/login_use_case.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'nickname_edit_event.dart';
+import 'nickname_edit_state.dart';
+
+class NicknameEditBloc extends Bloc<NicknameEditEvent, NicknameEditState> {
+  final LoginUseCase _loginUseCase;
+
+  NicknameEditBloc({required LoginUseCase loginUseCase})
+    : _loginUseCase = loginUseCase,
+      super(NicknameEditInitial()) {
+    on<CheckNicknameChangeAvailability>(_onCheckNicknameChangeAvailability);
+    on<SubmitNickname>(_onSubmitNickname);
+  }
+
+
+  Future<void> _onCheckNicknameChangeAvailability(
+    CheckNicknameChangeAvailability event,
+    Emitter<NicknameEditState> emit,
+  ) async {
+
+    if(event.isNewUser) {
+      emit(
+        NicknameChangeAvailable(
+          uid: event.uid,
+          isNewUser: true,
+          createdAt: DateTime.now().toIso8601String(),
+        ),
+      );
+      return;
+    }
+
+    final fetchedUserData = await _loginUseCase.getUserDataByUid(event.uid);
+
+    if (fetchedUserData == null) {
+      emit(NicknameDataFetchFailure());
+      return;
+    }
+
+    // 신규 유저 최초 1회 등록 시
+    if (fetchedUserData.updatedAt.isEmpty) {
+      emit(
+        NicknameChangeAvailable(
+          uid: event.uid,
+          isNewUser: true,
+          createdAt: fetchedUserData.createdAt,
+        ),
+      );
+      return;
+    }
+
+    try {
+      final updatedTime = DateTime.parse(fetchedUserData.updatedAt).toLocal();
+      final now = DateTime.now();
+      final diff = now.difference(updatedTime);
+
+      // 변경 후 72 시간 지남
+      if (diff.inHours >= 72) {
+        emit(
+          NicknameChangeAvailable(
+            uid: event.uid,
+            isNewUser: false,
+            createdAt: fetchedUserData.createdAt,
+            updatedAt: fetchedUserData.updatedAt,
+          ),
+        );
+      } else {
+        // 변경 후 72 시간 안지남
+        emit(NicknameChangeUnavailable(Duration(hours: 72) - diff));
+      }
+    } catch (_) {
+      emit(NicknameChangeUnavailable(Duration(hours: 72)));
+    }
+  }
+
+  // 닉네임 입력이 끝나면, 유저 정보 저장
+  Future<void> _onSubmitNickname(SubmitNickname event, Emitter emit) async {
+    try {
+      final currentState = state;
+
+      if (currentState is NicknameChangeAvailable) {
+        String uid = currentState.uid;
+        bool isNewUser = currentState.isNewUser;
+        String createdAt = currentState.createdAt;
+        String newNickname = event.nickname.trim();
+        String updatedAt = isNewUser ? '' : DateTime.now().toIso8601String();
+
+        final UserEntity updatedUser = UserEntity(
+          uid: uid,
+          nickname: newNickname,
+          createdAt: createdAt,
+          updatedAt: updatedAt,
+        );
+
+        if (isNewUser) {
+          await _loginUseCase.saveNewUser(updatedUser);
+          emit(NicknameSavedAndSignedIn());
+        } else {
+          await _loginUseCase.updateUserNickname(updatedUser);
+          emit(NicknameEditSuccess());
+        }
+      }
+    } catch (e) {
+      emit(NicknameEditFailure('닉네임 저장 에러 $e'));
+    }
+  }
+}

--- a/lib/ui/login/bloc/nickname_edit_event.dart
+++ b/lib/ui/login/bloc/nickname_edit_event.dart
@@ -1,0 +1,16 @@
+
+
+abstract class NicknameEditEvent {}
+
+class CheckNicknameChangeAvailability extends NicknameEditEvent {
+  final String uid;
+  final bool isNewUser;
+
+  CheckNicknameChangeAvailability({required this.uid, required this.isNewUser});
+}
+
+class SubmitNickname extends NicknameEditEvent {
+  final String nickname;
+
+  SubmitNickname({required this.nickname,});
+}

--- a/lib/ui/login/bloc/nickname_edit_state.dart
+++ b/lib/ui/login/bloc/nickname_edit_state.dart
@@ -1,0 +1,35 @@
+abstract class NicknameEditState {}
+
+class NicknameEditInitial extends NicknameEditState {
+  String uid = '';
+  bool isNewUser = true;
+  String createdAt = '';
+  String? updatedAt = '';
+}
+
+class NicknameChangeAvailable extends NicknameEditState {
+  final String uid;
+  final bool isNewUser;
+  final String createdAt;
+  final String? updatedAt;
+
+  NicknameChangeAvailable({required this.uid, required this.isNewUser, required this.createdAt, this.updatedAt});
+}
+
+class NicknameChangeUnavailable extends NicknameEditState {
+  final Duration remainingTime;
+
+  NicknameChangeUnavailable(this.remainingTime);
+}
+
+class NicknameEditSuccess extends NicknameEditState {}
+
+class NicknameEditFailure extends NicknameEditState {
+  final String message;
+
+  NicknameEditFailure(this.message);
+}
+
+class NicknameDataFetchFailure extends NicknameEditState {}
+
+class NicknameSavedAndSignedIn extends NicknameEditState {}

--- a/lib/ui/login/bloc/nickname_edit_state.dart
+++ b/lib/ui/login/bloc/nickname_edit_state.dart
@@ -1,11 +1,6 @@
 abstract class NicknameEditState {}
 
-class NicknameEditInitial extends NicknameEditState {
-  String uid = '';
-  bool isNewUser = true;
-  String createdAt = '';
-  String? updatedAt = '';
-}
+class NicknameEditInitial extends NicknameEditState {}
 
 class NicknameChangeAvailable extends NicknameEditState {
   final String uid;

--- a/lib/ui/login/view/edit_nickname_screen.dart
+++ b/lib/ui/login/view/edit_nickname_screen.dart
@@ -1,3 +1,4 @@
+import 'package:bread_place/config/constants/app_text_styles.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -145,16 +146,19 @@ class _EditNicknameScreenState extends State<EditNicknameScreen> {
                   children: [
                     // 텍스트 필드
                     Padding(
-                      padding: const EdgeInsets.fromLTRB(20, 30, 20, 30),
+                      padding: const EdgeInsets.fromLTRB(20, 30, 20, 0),
                       child: SizedBox(child: _inputTextField()),
                     ),
+
+                    _helperText(),
+                    SizedBox(height: 20),
 
                     PrimaryButton(
                       text: '저장',
                       onPressed: _isInputValid ? _saveNickname : null,
                     ),
 
-                    SizedBox(height: 20),
+                    SizedBox(height: 10),
 
                     PrimaryButton(
                       text: '랜덤 닉네임 생성',
@@ -188,7 +192,6 @@ class _EditNicknameScreenState extends State<EditNicknameScreen> {
         ),
       ],
       decoration: InputDecoration(
-        helperText: '영어 대소문자, 숫자, 한글만 입력 가능\n최대 $maxLength자',
         focusedBorder: OutlineInputBorder(
           borderSide: BorderSide(color: AppColors.primary),
         ),
@@ -199,6 +202,36 @@ class _EditNicknameScreenState extends State<EditNicknameScreen> {
           icon: Icon(CupertinoIcons.xmark_circle_fill),
         ),
         hintText: '사용하실 닉네임을 입력해주세요',
+      ),
+    );
+  }
+
+  Widget _helperText() {
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(26, 0, 20, 30),
+        child: Text.rich(
+          TextSpan(
+            text: '영어 대소문자, 숫자, 한글만 입력 가능'
+                '\n닉네임 변경은 최소 ',
+            style: AppTextStyles.pretendardRegular.copyWith(
+              fontSize: 14,
+            ),
+            children: [
+              TextSpan(
+                text: '72시간 마다 1회',
+                style: AppTextStyles.pretendardSemiBold.copyWith(
+                  fontSize: 14,
+                  color: AppColors.primary,
+                ),
+              ),
+              TextSpan(
+                text: ' 가능합니다',
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/lib/ui/login/view/edit_nickname_screen.dart
+++ b/lib/ui/login/view/edit_nickname_screen.dart
@@ -247,27 +247,26 @@ class _EditNicknameScreenState extends State<EditNicknameScreen> {
         padding: const EdgeInsets.fromLTRB(26, 0, 20, 30),
         child: Text.rich(
           TextSpan(
-            text:
-                '영어 대소문자, 숫자, 한글만 입력 가능'
+            text: '영어 대소문자, 숫자, 한글만 입력 가능'
                 '\n닉네임은 ',
             style: AppTextStyles.pretendardRegular.copyWith(fontSize: 14),
             children: [
               TextSpan(
-                text: '가입 시 1회 등록',
-                style: AppTextStyles.pretendardSemiBold.copyWith(
+                text: '가입 후 1회 자유롭게 변경',
+                style: AppTextStyles.pretendardRegular.copyWith(
                   fontSize: 14,
                   color: AppColors.primary,
                 ),
               ),
-              TextSpan(text: '되며, 이후에는 '),
+              TextSpan(text: '할 수 있습니다.\n단, '),
               TextSpan(
-                text: '72시간마다 1회',
-                style: AppTextStyles.pretendardSemiBold.copyWith(
+                text: '2회차 이후 72시간마다 1회',
+                style: AppTextStyles.pretendardRegular.copyWith(
                   fontSize: 14,
                   color: AppColors.primary,
                 ),
               ),
-              TextSpan(text: ' \n변경이 가능합니다.'),
+              TextSpan(text: ' 변경이 가능합니다.'),
             ],
           ),
         ),

--- a/lib/ui/login/view/edit_nickname_screen.dart
+++ b/lib/ui/login/view/edit_nickname_screen.dart
@@ -1,4 +1,3 @@
-import 'package:bread_place/config/constants/app_text_styles.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -12,6 +11,10 @@ import 'package:bread_place/ui/login/bloc/login_event.dart';
 import 'package:bread_place/utils/generate_timestamp_nickname.dart';
 import 'package:bread_place/ui/common_widgets/common_snack_bar.dart';
 import 'package:bread_place/ui/login/bloc/login_state.dart';
+import 'package:bread_place/config/constants/app_text_styles.dart';
+import 'package:bread_place/ui/login/bloc/nickname_edit_bloc.dart';
+import 'package:bread_place/ui/login/bloc/nickname_edit_event.dart';
+import 'package:bread_place/ui/login/bloc/nickname_edit_state.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
@@ -31,6 +34,7 @@ class _EditNicknameScreenState extends State<EditNicknameScreen> {
   void initState() {
     super.initState();
     _controller.addListener(_validateInput);
+    _canChangeNickname();
   }
 
   @override
@@ -45,14 +49,25 @@ class _EditNicknameScreenState extends State<EditNicknameScreen> {
     });
   }
 
+  void _canChangeNickname() {
+    final loginState = context.read<LoginBloc>().state;
+    // 기존 유저
+    if(loginState is Authenticated){
+      context.read<NicknameEditBloc>().add(CheckNicknameChangeAvailability(uid: loginState.uid, isNewUser: false));
+      // 신규 유저
+    } else if (loginState is NewUserRequireNickname) {
+      context.read<NicknameEditBloc>().add(CheckNicknameChangeAvailability(uid: loginState.uid, isNewUser: true));
+    }
+  }
+
   void _saveNickname() {
     _unfocusedKeyboard();
 
     if (_controller.text.isEmpty) {
-     CommonSnackBar.showInfo(context, '1글자 이상 입력해주세요');
-     return;
+      CommonSnackBar.showInfo(context, '1글자 이상 입력해주세요');
+      return;
     }
-    context.read<LoginBloc>().add(NicknameSubmitted(_controller.text));
+    context.read<NicknameEditBloc>().add(SubmitNickname(nickname: _controller.text));
   }
 
   void _showCancelDialogIfNeeded(BuildContext context) {
@@ -133,41 +148,53 @@ class _EditNicknameScreenState extends State<EditNicknameScreen> {
             onTap: () => _unfocusedKeyboard(),
             child: Padding(
               padding: const EdgeInsets.all(8.0),
-              child: BlocListener<LoginBloc, LoginState>(
+              child: BlocListener<NicknameEditBloc, NicknameEditState>(
                 listener: (context, state) {
-                  if (state is NicknameEdited) {
+                  if (state is NicknameEditSuccess) {
                     _showSuccessMessage();
-
+                    _checkLoginStatusAndDispose();
                   } else if (state is NicknameEditFailure) {
                     _showFailureMessage();
                   }
                 },
                 child: Column(
-                  children: [
-                    // 텍스트 필드
-                    Padding(
-                      padding: const EdgeInsets.fromLTRB(20, 30, 20, 0),
-                      child: SizedBox(child: _inputTextField()),
-                    ),
+                      children: [
+                        // 텍스트 필드
+                        Padding(
+                          padding: const EdgeInsets.fromLTRB(20, 30, 20, 0),
+                          child: SizedBox(child: _inputTextField()),
+                        ),
 
-                    _helperText(),
-                    SizedBox(height: 20),
+                        _helperText(),
+                        SizedBox(height: 20),
 
-                    PrimaryButton(
-                      text: '저장',
-                      onPressed: _isInputValid ? _saveNickname : null,
-                    ),
+                        BlocSelector<NicknameEditBloc, NicknameEditState, Duration?>(
+                            selector: (state) {
+                              if(state is NicknameChangeUnavailable) {
+                                return state.remainingTime;
+                              } else {
+                                return null;
+                              }
+                            },
+                          builder: (context, state) {
+                            return  _showRemainingTime(state);
+                          }),
 
-                    SizedBox(height: 10),
+                        PrimaryButton(
+                          text: '저장',
+                          onPressed: (_isInputValid) ? _saveNickname : null,
+                        ),
 
-                    PrimaryButton(
-                      text: '랜덤 닉네임 생성',
-                      onPressed: () {
-                        _getRandomNickname();
-                      },
-                      backgroundColor: AppColors.icon,
-                    ),
-                  ],
+                        SizedBox(height: 10),
+
+                        PrimaryButton(
+                          text: '랜덤 닉네임 생성',
+                          onPressed: () {
+                            _getRandomNickname();
+                          },
+                          backgroundColor: AppColors.icon,
+                        ),
+                      ],
                 ),
               ),
             ),
@@ -213,23 +240,46 @@ class _EditNicknameScreenState extends State<EditNicknameScreen> {
         padding: const EdgeInsets.fromLTRB(26, 0, 20, 30),
         child: Text.rich(
           TextSpan(
-            text: '영어 대소문자, 숫자, 한글만 입력 가능'
-                '\n닉네임 변경은 최소 ',
-            style: AppTextStyles.pretendardRegular.copyWith(
-              fontSize: 14,
-            ),
+            text:
+                '영어 대소문자, 숫자, 한글만 입력 가능'
+                '\n닉네임은 ',
+            style: AppTextStyles.pretendardRegular.copyWith(fontSize: 14),
             children: [
               TextSpan(
-                text: '72시간 마다 1회',
+                text: '가입 시 1회 등록',
                 style: AppTextStyles.pretendardSemiBold.copyWith(
                   fontSize: 14,
                   color: AppColors.primary,
                 ),
               ),
+              TextSpan(text: '되며, 이후에는 '),
               TextSpan(
-                text: ' 가능합니다',
+                text: '72시간마다 1회',
+                style: AppTextStyles.pretendardSemiBold.copyWith(
+                  fontSize: 14,
+                  color: AppColors.primary,
+                ),
               ),
+              TextSpan(text: ' \n변경이 가능합니다.'),
             ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _showRemainingTime(Duration? remainingTime) {
+    if(remainingTime == null) return SizedBox.shrink();
+
+    return Padding(
+      padding: const EdgeInsets.only(left: 26.0, bottom: 20),
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: Text(
+          '닉네임 변경 가능까지 ${remainingTime.inHours}시간 ${remainingTime.inMinutes.remainder(60)}분 남았습니다',
+          style: AppTextStyles.pretendardRegular.copyWith(
+            fontSize: 14,
+            color: AppColors.error,
           ),
         ),
       ),

--- a/lib/ui/login/view/edit_nickname_screen.dart
+++ b/lib/ui/login/view/edit_nickname_screen.dart
@@ -34,7 +34,7 @@ class _EditNicknameScreenState extends State<EditNicknameScreen> {
 
   @override
   void dispose() {
-    _clearTextController();
+    _removeTextControllerListener();
     super.dispose();
   }
 
@@ -69,6 +69,11 @@ class _EditNicknameScreenState extends State<EditNicknameScreen> {
   }
 
   void _clearTextController() {
+    _controller.clear();
+    _validateInput();
+  }
+
+  void _removeTextControllerListener() {
     _controller.removeListener(_validateInput);
     _controller.clear();
   }

--- a/lib/ui/login/view/edit_nickname_screen.dart
+++ b/lib/ui/login/view/edit_nickname_screen.dart
@@ -84,7 +84,6 @@ class _EditNicknameScreenState extends State<EditNicknameScreen> {
 
   void _showSuccessMessage() {
     CommonSnackBar.showSuccess(context, '닉네임이 성공적으로 변경되었습니다');
-    Future.delayed(Duration(seconds: 1));
     context.pop();
   }
 

--- a/lib/ui/login/view/edit_nickname_screen.dart
+++ b/lib/ui/login/view/edit_nickname_screen.dart
@@ -112,6 +112,10 @@ class _EditNicknameScreenState extends State<EditNicknameScreen> {
     CommonSnackBar.showError(context, '닉네임 변경에 실패했습니다');
   }
 
+  void _showSignInMessage() {
+    CommonSnackBar.showSuccess(context, '회원가입에 성공 했습니다.');
+  }
+
   Widget _buildCancelDialog(BuildContext context) {
     return CommonDialog(
       title: '닉네임이 저장되지 않았습니다',
@@ -155,6 +159,9 @@ class _EditNicknameScreenState extends State<EditNicknameScreen> {
                     _checkLoginStatusAndDispose();
                   } else if (state is NicknameEditFailure) {
                     _showFailureMessage();
+                  } else if (state is NicknameSavedAndSignedIn) {
+                    _showSignInMessage();
+                    _checkLoginStatusAndDispose();
                   }
                 },
                 child: Column(

--- a/lib/ui/login/view/login_screen_main.dart
+++ b/lib/ui/login/view/login_screen_main.dart
@@ -1,4 +1,3 @@
-import 'package:bread_place/config/constants/app_social_platform.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
@@ -8,6 +7,7 @@ import 'package:bread_place/config/constants/app_colors.dart';
 import 'package:bread_place/config/constants/app_text_styles.dart';
 import 'package:bread_place/config/routing/routes.dart';
 import 'package:bread_place/ui/login/bloc/login_state.dart';
+import 'package:bread_place/config/constants/app_social_platform.dart';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
@@ -25,7 +25,7 @@ class _LoginScreenMainState extends State<LoginScreenMain> {
     return BlocListener<LoginBloc, LoginState>(
       listener: (context, state) {
         // 신규 유저 -> 닉네임 입력 화면으로 이동
-        if (state is OpenNicknameEditScreen) {
+        if (state is NewUserRequireNickname) {
           context.push(Routes.editNickName);
           // 그 외 상태 -> 홈으로 보내기
         } else {

--- a/lib/ui/mypage/view/mypage_screen_main.dart
+++ b/lib/ui/mypage/view/mypage_screen_main.dart
@@ -1,3 +1,4 @@
+import 'package:bread_place/ui/common_widgets/common_dialog.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
@@ -13,6 +14,13 @@ import 'package:go_router/go_router.dart';
 
 class MypageScreenMain extends StatelessWidget {
   const MypageScreenMain({super.key});
+  
+  void _showWithdarwDialog(BuildContext context){
+    showDialog(
+        context: context,
+        builder: (_) => _buildWithdrawDialog(context)
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -25,7 +33,7 @@ class MypageScreenMain extends StatelessWidget {
           child: BlocBuilder<LoginBloc, LoginState>(
             builder: (context, state) {
               if (state is Authenticated) {
-                return _loginUserView(state);
+                return _loginUserView(context, state);
               } else if (state is Unauthenticated) {
                 return _guestUserView(context);
               } else {
@@ -38,6 +46,21 @@ class MypageScreenMain extends StatelessWidget {
     );
   }
 
+  Widget _buildWithdrawDialog(BuildContext context){
+    return CommonDialog(
+        content: '회원 정보가 삭제됩니다. 정말 탈퇴하시겠습니까?',
+        positiveButtonText: '탈퇴',
+        negativeButtonText: '취소',
+        onTapPositiveButton: (){
+          context.read<LoginBloc>().add(WithDraw());
+          context.pop();
+        },
+      onTapNegativeButton: (){
+          context.pop();
+      },
+    );
+  }
+
   Widget _loadingView() {
     return Center(
       child: SizedBox(
@@ -46,7 +69,7 @@ class MypageScreenMain extends StatelessWidget {
     );
   }
 
-  Widget _loginUserView(Authenticated state) {
+  Widget _loginUserView(BuildContext context, Authenticated state) {
     return Column(
       children: [
         _loginUserInfoContainer(
@@ -61,7 +84,9 @@ class MypageScreenMain extends StatelessWidget {
         _appMenuList(),
         SizedBox(height: 10),
 
-        AccountMenuList(),
+        AccountMenuList(
+          onWithdrawButtonTapped: () => _showWithdarwDialog(context),
+        ),
       ],
     );
   }
@@ -174,7 +199,12 @@ class MypageScreenMain extends StatelessWidget {
 }
 
 class AccountMenuList extends StatelessWidget {
-  const AccountMenuList({super.key});
+  final VoidCallback onWithdrawButtonTapped;
+
+  const AccountMenuList({
+    required this.onWithdrawButtonTapped,
+    super.key
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -191,7 +221,14 @@ class AccountMenuList extends StatelessWidget {
               color: AppColors.fontGrey,
             ),
           ),
-          MypageMenuItem(text: '회원 탈퇴'),
+          MypageMenuItem(
+            onTap: onWithdrawButtonTapped,
+            text: '회원 탈퇴',
+            widget: Icon(
+              CupertinoIcons.square_arrow_right,
+              color: AppColors.fontGrey,
+            ),
+          ),
         ],
       ),
     );

--- a/lib/ui/mypage/view/mypage_screen_main.dart
+++ b/lib/ui/mypage/view/mypage_screen_main.dart
@@ -301,17 +301,10 @@ class UserMenuList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final state = context.read<LoginBloc>().state;
-
     void onNicknameEditTap() {
+      final state = context.read<LoginBloc>().state;
+
       if (state is Authenticated) {
-        context.read<LoginBloc>().add(
-          OpenNicknameEditScreen(
-            uid: state.uid,
-            createdAt: state.createdAt,
-            oldNickname: state.nickname,
-          ),
-        );
         context.push(Routes.editNickName);
       }
     }

--- a/lib/ui/mypage/view/mypage_screen_main.dart
+++ b/lib/ui/mypage/view/mypage_screen_main.dart
@@ -264,17 +264,10 @@ class UserMenuList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final state = context.read<LoginBloc>().state;
-
     void onNicknameEditTap() {
+      final state = context.read<LoginBloc>().state;
+
       if (state is Authenticated) {
-        context.read<LoginBloc>().add(
-          OpenNicknameEditScreen(
-            uid: state.uid,
-            createdAt: state.createdAt,
-            oldNickname: state.nickname,
-          ),
-        );
         context.push(Routes.editNickName);
       }
     }

--- a/lib/ui/mypage/view/mypage_screen_main.dart
+++ b/lib/ui/mypage/view/mypage_screen_main.dart
@@ -48,7 +48,7 @@ class MypageScreenMain extends StatelessWidget {
 
   Widget _buildWithdrawDialog(BuildContext context){
     return CommonDialog(
-        content: '회원 정보가 삭제됩니다. 정말 탈퇴하시겠습니까?',
+        content: '회원 정보와 리뷰가 삭제됩니다. 정말 탈퇴하시겠습니까?',
         positiveButtonText: '탈퇴',
         negativeButtonText: '취소',
         onTapPositiveButton: (){


### PR DESCRIPTION
### Issue

- Close: #126 

---

### 🔴 Type of Work

- [x] feat: 새로운 기능 추가
- [ ] fix: 버그 수정
- [ ] refactor: 리팩토링
- [ ] style: 스타일 수정, 폴더 구조 조정
- [ ] docs: 문서 수정
- [ ] chore: 릴리즈 준비 작업

---

### 🔵 Description

> 구현하거나 변경한 내용을 작성해 주세요. 어떤 화면, 기능, 모듈에 영향이 있었는지 명시해 주세요.

- [x] login_bloc 에 있던 닉네임 변경 관련 로직을 nickname_edit_bloc 으로 이동, 분리
- [x] 닉네임 변경 화면에 시간 제한 관련 안내문구 추가
- [x] 텍스트필드 내 엑스 버튼을 통해 텍스트를 비울 경우, 저장 버튼이 비활성화 되지 않는 오류 수정

---

### 📋 Checklist

- [x] 빌드 에러가 없는 것을 확인했습니다.
- [x] 머지 대상 브랜치가 올바른지 확인했습니다.
- [x] 프로젝트의 코드 스타일 및 컨벤션을 따랐습니다.

---

### 📝 Notes for Reviewers

> 리뷰어가 참고하면 좋을 추가적인 맥락이나 유의사항이 있다면 작성해 주세요,

- 로그인 화면에서 NewUserRequireNickname 상태 발생 -> BlocListener 를 통해 닉네임 등록 화면으로 이동합니다.
- isNewuser 변수만으로는 최초 가입 이후 1회차인지 판단이 안돼서 updatedAt 으로 구별했습니다. 근데 보기 좀 어려운거같아서 고민입니다. 관련 주석을 달긴 했는데 좋은 방법이 있다면 알려주세용
  - 최초 가입 -> uid 가 서버에 등록되지 않은 상태
  - 최초 가입 이후 1회 재등록 -> uid 가 서버에 있음 + updatedAt 은 빈값
  - 기존 회원 -> uid 가 서버에 있음 + updatedAt 도 있음