### PR TITLE
[Feat] #149 리뷰 추가와 좋아요 추가 시 로그인 확인

### DIFF
--- a/lib/ui/bakery_detail/view/bakery_detail_screen.dart
+++ b/lib/ui/bakery_detail/view/bakery_detail_screen.dart
@@ -47,9 +47,7 @@ class _BakeryDetailScreenState extends State<BakeryDetailScreen> {
   }
 
   void _onAddReviewButtonTapped(Bakery bakery) {
-    final loginState = context.read<LoginBloc>().state;
-
-    if (loginState is Authenticated) {
+    _doIfLogined((){
       final bloc = context.read<BakeryDetailBloc>();
 
       context.push(
@@ -59,23 +57,17 @@ class _BakeryDetailScreenState extends State<BakeryDetailScreen> {
             'bloc': bloc,
           }
       );
-    } else {
-      context.go(Routes.login);
-    }
+    });
   }
 
   void _onHeartButtonTapped(Bakery bakery, bool isLiked) {
-    final loginState = context.read<LoginBloc>().state;
-
-    if (loginState is Authenticated) {
+    _doIfLogined(() {
       bool notifyByDefault = false;
 
       isLiked
-        ? context.read<LikeBloc>().add(RemoveLike(bakery: bakery, isNotificationAllowed: notifyByDefault))
-        : context.read<LikeBloc>().add(AddLike(bakery: bakery, isNotificationAllowed: notifyByDefault));
-    } else {
-      context.go(Routes.login);
-    }
+          ? context.read<LikeBloc>().add(RemoveLike(bakery: bakery, isNotificationAllowed: notifyByDefault))
+          : context.read<LikeBloc>().add(AddLike(bakery: bakery, isNotificationAllowed: notifyByDefault));
+    });
   }
 
   // 현재 좋아요 상태인지 체크
@@ -94,6 +86,16 @@ class _BakeryDetailScreenState extends State<BakeryDetailScreen> {
       if (state.isLastReview || state.isFetchingReviews) return;
 
       context.read<BakeryDetailBloc>().add(OnFetchReviews());
+    }
+  }
+
+  void _doIfLogined(VoidCallback action) {
+    final loginState = context.read<LoginBloc>().state;
+
+    if(loginState is Authenticated){
+      action();
+    } else {
+      context.go(Routes.login);
     }
   }
 

--- a/lib/ui/bakery_detail/view/bakery_detail_screen.dart
+++ b/lib/ui/bakery_detail/view/bakery_detail_screen.dart
@@ -1,4 +1,6 @@
 import 'package:bread_place/domain/entities/bakery_review_entity.dart';
+import 'package:bread_place/ui/login/bloc/login_bloc.dart';
+import 'package:bread_place/ui/login/bloc/login_state.dart';
 import 'package:bread_place/utils/iso_date_extensions.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -45,23 +47,35 @@ class _BakeryDetailScreenState extends State<BakeryDetailScreen> {
   }
 
   void _onAddReviewButtonTapped(Bakery bakery) {
-    final bloc = context.read<BakeryDetailBloc>();
+    final loginState = context.read<LoginBloc>().state;
 
-    context.push(
-        Routes.addReview,
-        extra: {
-          'bakery': bakery,
-          'bloc': bloc,
-        }
-    );
+    if (loginState is Authenticated) {
+      final bloc = context.read<BakeryDetailBloc>();
+
+      context.push(
+          Routes.addReview,
+          extra: {
+            'bakery': bakery,
+            'bloc': bloc,
+          }
+      );
+    } else {
+      context.go(Routes.login);
+    }
   }
 
   void _onHeartButtonTapped(Bakery bakery, bool isLiked) {
-    bool notifyByDefault = false;
+    final loginState = context.read<LoginBloc>().state;
 
-    isLiked
+    if (loginState is Authenticated) {
+      bool notifyByDefault = false;
+
+      isLiked
         ? context.read<LikeBloc>().add(RemoveLike(bakery: bakery, isNotificationAllowed: notifyByDefault))
         : context.read<LikeBloc>().add(AddLike(bakery: bakery, isNotificationAllowed: notifyByDefault));
+    } else {
+      context.go(Routes.login);
+    }
   }
 
   // 현재 좋아요 상태인지 체크


### PR DESCRIPTION
### Issue

- Close: #149 

---

### 🔴 Type of Work

- [x] feat: 새로운 기능 추가
- [ ] fix: 버그 수정
- [ ] refactor: 리팩토링
- [ ] style: 스타일 수정, 폴더 구조 조정
- [ ] docs: 문서 수정
- [ ] chore: 릴리즈 준비 작업

---

### 🔵 Description

> 구현하거나 변경한 내용을 작성해 주세요. 어떤 화면, 기능, 모듈에 영향이 있었는지 명시해 주세요.

- [x] 리뷰 추가와 좋아요 추가 시 로그인이 되어있지 않으면 로그인 화면으로 이동하도록 변경

---

### 📋 Checklist

- [x] 빌드 에러가 없는 것을 확인했습니다.
- [x] 머지 대상 브랜치가 올바른지 확인했습니다.
- [x] 프로젝트의 코드 스타일 및 컨벤션을 따랐습니다.

---

### 📝 Notes for Reviewers

> 리뷰어가 참고하면 좋을 추가적인 맥락이나 유의사항이 있다면 작성해 주세요,

- 처음에는 멀티블록 프로바이더에 _loginBloc 객체를 .value로 넣어줬는데 오류가 생겼습니다.  
   like쪽 구조를 참고해서 코드를 작성하긴 했는데 왜 외부에서 값을 주입하지 않고도 LoginBloc의 State가 가져와지는지 모르겠어요!

