### PR TITLE
[Fix] #161 앱 아이콘 변경 후 안드로이드 푸시 알림이 오지 않는 문제 수정

### DIFF
--- a/android/app/src/main/kotlin/com/example/bread_place/geofence/LocationForegroundService.kt
+++ b/android/app/src/main/kotlin/com/example/bread_place/geofence/LocationForegroundService.kt
@@ -52,8 +52,8 @@ class LocationForegroundService : Service() {
     // Foreground 서비스를 시작하고, 사용자에게 위치 추적 중임을 알리는 Notification 생성
     private fun startForegroundService() {
         val notification = NotificationCompat.Builder(this, NotificationConstants.CHANNEL_ID)
-            .setContentTitle("위치 추적 중")
-            .setContentText("사용자의 위치 정보를 사용하고 있습니다.")
+            .setContentTitle("위치 정보 사용 중")
+            .setContentText("저장한 빵집에 가까워지면 알려드리기 위해 사용자의 위치 정보를 사용하고 있습니다.")
             .setSmallIcon(android.R.drawable.ic_menu_mylocation)
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .build()

--- a/lib/data/services/notification/local_notification_service.dart
+++ b/lib/data/services/notification/local_notification_service.dart
@@ -9,7 +9,7 @@ class LocalNotificationService {
   Future<void> init() async {
     // Android 플랫폼용 초기화 설정 (앱 아이콘 설정)
     const AndroidInitializationSettings androidInitializationSettings =
-        AndroidInitializationSettings('@mipmap/ic_launcher');
+        AndroidInitializationSettings('@mipmap/ic_bread_place_logo');
 
     // iOS 플랫폼용 초기화 설정 (권한 요청 여부 설정)
     const DarwinInitializationSettings iosInitializationSettings =

--- a/lib/domain/usecases/geofencing_use_case.dart
+++ b/lib/domain/usecases/geofencing_use_case.dart
@@ -55,7 +55,7 @@ class GeofencingUseCase {
 
       final notificationEntity = NotificationEntity(
         title: '가고싶던 빵집이 근처에 있어요!',
-        body: '$displayName 에 진입',
+        body: '$displayName 근처에 진입',
       );
 
       _notificationRepository.showNotification(notificationEntity);


### PR DESCRIPTION
### Issue

- Close: #161 

---

### 🔴 Type of Work

- [ ] feat: 새로운 기능 추가
- [x] fix: 버그 수정
- [ ] refactor: 리팩토링
- [ ] style: 스타일 수정, 폴더 구조 조정
- [ ] docs: 문서 수정
- [ ] chore: 릴리즈 준비 작업

---

### 🔵 Description

> 구현하거나 변경한 내용을 작성해 주세요. 어떤 화면, 기능, 모듈에 영향이 있었는지 명시해 주세요.

- [x] 안드로이드 푸시 알림의 아이콘 수정

---

### 📋 Checklist

- [x] 빌드 에러가 없는 것을 확인했습니다.
- [x] 머지 대상 브랜치가 올바른지 확인했습니다.
- [x] 프로젝트의 코드 스타일 및 컨벤션을 따랐습니다.

---

### 📝 Notes for Reviewers

> 리뷰어가 참고하면 좋을 추가적인 맥락이나 유의사항이 있다면 작성해 주세요,

- 푸시 알림 필수 설정값으로 아이콘 경로가 들어가는데, 기본 제공되는 플러터 로고를 삭제한 뒤 새로운 로고를 경로를 설정해주지 않아서 생긴 문제였습니다